### PR TITLE
lm3: friend presence WIP + relay/NAT APIs (source-only, no binaries)

### DIFF
--- a/diag.go
+++ b/diag.go
@@ -1,0 +1,11 @@
+package nex
+
+import "time"
+
+// ts returns a wall-clock timestamp for server-side diagnostic lines. The nncs
+// responder and the emulator both timestamp their output; the NEX logs did not,
+// which made it impossible to order events (probes vs Register vs error) across
+// processes. Prefix the few events that mark a session's timeline.
+func ts() string {
+	return time.Now().Format("15:04:05.000")
+}

--- a/endpoint.go
+++ b/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -66,8 +67,9 @@ type Endpoint struct {
 	// each player's NAT type and latency (lost when the games moved off the previous stack).
 	OnNATProperties func(pid uint64, natMap, natFilter, rtt uint32)
 
-	handlers map[uint16]RMCHandler
-	mu       sync.RWMutex
+	handlers       map[uint16]RMCHandler
+	fallbackHandler RMCHandler
+	mu             sync.RWMutex
 
 	// customPacketHandlers handle non-standard PRUDP packet types (e.g. SSBU's Pia
 	// 5.19 type-8 keepalive, which the base SYN/CONNECT/DATA/PING/DISCONNECT switch
@@ -137,6 +139,18 @@ func (e *Endpoint) FindConnectionByID(id uint32) *Connection {
 // (that path uses FindConnectionByID on the exact RVCID = the live connection), giving a
 // "hole-punch ok" that masks the real failure. Net effect for ACNH: 2618-0502 "other consoles
 // not responding". Always hand back the highest-ID (newest) connection for the PID.
+
+// ConnectionIDs returns the ids of all live connections. The station relay uses it to
+// validate the source/destination connection ids it sniffs from PRUDP headers.
+func (e *Endpoint) ConnectionIDs() []uint32 {
+	e.connMu.Lock()
+	defer e.connMu.Unlock()
+	ids := make([]uint32, 0, len(e.connections))
+	for id := range e.connections {
+		ids = append(ids, id)
+	}
+	return ids
+}
 func (e *Endpoint) FindConnectionByPID(pid uint64) *Connection {
 	e.connMu.Lock()
 	defer e.connMu.Unlock()
@@ -170,9 +184,19 @@ func (e *Endpoint) Register(protocolID uint16, h RMCHandler) {
 	e.mu.Unlock()
 }
 
+// RegisterFallback sets a handler called when no protocol-specific handler is registered.
+func (e *Endpoint) RegisterFallback(h RMCHandler) {
+	e.mu.Lock()
+	e.fallbackHandler = h
+	e.mu.Unlock()
+}
+
 func (e *Endpoint) handler(protocolID uint16) (RMCHandler, bool) {
 	e.mu.RLock()
 	h, ok := e.handlers[protocolID]
+	if !ok && e.fallbackHandler != nil {
+		h, ok = e.fallbackHandler, true
+	}
 	e.mu.RUnlock()
 	return h, ok
 }
@@ -410,7 +434,7 @@ func (c *Connection) processCONNECT(p *Packet) {
 		fmt.Printf("[PRUDP] CONNECT login failed from %s: %v (payload=%d bytes)\n", c.RemoteAddr, err, len(p.Payload))
 		return // bad ticket — ignore
 	}
-	fmt.Printf("[PRUDP] CONNECT ok from %s pid=%d secure=%v\n", c.RemoteAddr, c.PID, c.Endpoint.Secure)
+	fmt.Printf("[%s] [PRUDP] CONNECT ok from %s pid=%d secure=%v\n", ts(), c.RemoteAddr, c.PID, c.Endpoint.Secure)
 
 	ack := &Packet{
 		Type:       PacketCONNECT,
@@ -547,11 +571,50 @@ func (c *Connection) processPing(p *Packet) {
 	}
 }
 
+// handlerWatchdogTimeout is how long an RMC request may take before every
+// goroutine stack is dumped to the log. A handler that never finishes (stuck
+// mutex, blocked socket write, deadlock) otherwise just leaves the console
+// polling an unanswered call forever — which is exactly what a matchmaking
+// "communication error" hang looks like from the outside.
+const handlerWatchdogTimeout = 10 * time.Second
+
+// dumpStacks renders every goroutine stack (for the watchdog / panic handler).
+func dumpStacks() string {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	if n == len(buf) {
+		buf = append(buf, []byte("\n[stack dump truncated]\n")...)
+		return string(buf)
+	}
+	return string(buf[:n])
+}
+
 func (c *Connection) dispatchRMC(payload []byte) {
 	req, err := ParseRMC(c.Settings, payload)
 	if err != nil || req.Mode != RMCRequest {
 		return
 	}
+
+	// Watchdog: if this request is not answered in time, the handler is stuck —
+	// dump every goroutine stack so the blocked location is visible in the log.
+	timer := time.AfterFunc(handlerWatchdogTimeout, func() {
+		fmt.Printf("[NEX] WATCHDOG: proto=%#x method=%d call=%d pid=%d not answered after %s\n%s\n",
+			req.Protocol, req.Method, req.CallID, c.PID, handlerWatchdogTimeout, dumpStacks())
+	})
+	defer timer.Stop()
+
+	// Panic recovery: without this a panicking handler crashes the whole process
+	// (gws's Recovery would swallow it and leave the client waiting forever on a
+	// response that will never come). Answer with an error so the game can fail
+	// loudly, and dump the stack so the bug is recorded.
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("[NEX] PANIC proto=%#x method=%d call=%d pid=%d: %v\n%s\n",
+				req.Protocol, req.Method, req.CallID, c.PID, r, dumpStacks())
+			c.SendRMC(NewRMCError(c.Settings, req.Protocol, req.CallID, ResultCoreUnknown))
+		}
+	}()
+
 	if c.Endpoint.OnRMC != nil {
 		c.Endpoint.OnRMC(c, req)
 	}
@@ -642,6 +705,10 @@ func (c *Connection) sendData(data []byte) {
 
 // sendOneFragment sends a single reliable DATA fragment, allocating the next
 // reliable sequence id under the lock (so concurrent/async sends stay ordered).
+// The socket write itself happens OUTSIDE the lock: WriteMessage can block on
+// TCP backpressure when a client stops reading, and holding c.mu across it
+// would wedge every other send on the connection (including the retransmit
+// loop), turning one stuck client into a hung matchmaking handler.
 func (c *Connection) sendOneFragment(chunk []byte, fragmentID uint8) {
 	c.mu.Lock()
 	pid := c.outReliable
@@ -661,8 +728,9 @@ func (c *Connection) sendOneFragment(chunk []byte, fragmentID uint8) {
 	}
 	c.outReliable++
 	encoded := EncodePacket(pkt)
-	c.send(encoded)
 	c.mu.Unlock()
+
+	c.send(encoded)
 
 	// Remember it for retransmission until the console acks it.
 	c.pendingMu.Lock()
@@ -708,8 +776,12 @@ func (c *Connection) retransmitLoop() {
 		c.pendingMu.Unlock()
 		for _, enc := range batch {
 			c.mu.Lock()
-			c.send(enc)
+			live := c.state != stateClosed
 			c.mu.Unlock()
+			if !live {
+				return
+			}
+			c.send(enc)
 		}
 	}
 }

--- a/matchmaking_acnh_test.go
+++ b/matchmaking_acnh_test.go
@@ -203,3 +203,42 @@ func TestFriendNotificationsEmptyWithoutSource(t *testing.T) {
 		t.Fatalf("sans FriendPIDs la liste doit rester vide : %+v", got)
 	}
 }
+
+// Le hook (LM3) : l'hôte crée sa salle au m38, le jeu publie la « porte ouverte » (type 101,
+// Param1=gid, Param2=1) via PublishNotification, l'ami la voit au m13, et elle disparaît
+// quand l'hôte détruit la salle.
+func TestFriendSessionHookPublishesForFriends(t *testing.T) {
+	m := NewMatchmaking()
+	const me, host = uint64(1800000001), uint64(1800000002)
+	m.FriendPIDs = func(pid uint64) []uint64 { return []uint64{host} }
+	m.OnFriendSessionCreated = func(pid uint64, gid uint32) {
+		m.PublishNotification(pid, 101, &NotificationEvent{PIDSource: pid, Type: 101, Param1: uint64(gid), Param2: 1})
+	}
+
+	conn := &Connection{PID: host}
+	m.mu.Lock()
+	g := m.createGathering(conn, &MatchmakeSession{})
+	gid := g.session.ID
+	m.mu.Unlock()
+	m.OnFriendSessionCreated(host, gid)
+
+	got := m.friendNotificationsFor(me, []uint32{101})
+	if len(got) != 1 || got[0].PIDSource != host || got[0].Param1 != uint64(gid) || got[0].Param2 != 1 {
+		t.Fatalf("l'ami doit voir la salle ouverte (gid=%d, Param1=gid, Param2=1) : %+v", gid, got)
+	}
+	if got := m.friendNotificationsFor(me, []uint32{102}); len(got) != 0 {
+		t.Fatalf("les autres types interrogés doivent rester vides : %+v", got)
+	}
+
+	m.notif.forget(host)
+	if got := m.friendNotificationsFor(me, []uint32{101}); len(got) != 0 {
+		t.Fatalf("salle détruite : plus rien au m13 : %+v", got)
+	}
+}
+
+// Le hook est nil par défaut : ACNH publie lui-même au m9, MK8/S2/Smash inchangés.
+func TestFriendSessionHookNilByDefault(t *testing.T) {
+	if NewMatchmaking().OnFriendSessionCreated != nil {
+		t.Fatal("OnFriendSessionCreated doit être nil par défaut")
+	}
+}

--- a/matchmaking_handlers.go
+++ b/matchmaking_handlers.go
@@ -93,6 +93,30 @@ type gathering struct {
 // Matchmaking is the in-memory matchmaking store + handlers, replicating the
 // proven server's session lifecycle (create/join, participant tracking) and the
 // server→client Participate notification the console's Pia waits on.
+// rmcTrace is a rolling ring of RMC calls for one connection.
+type rmcTrace [10]struct {
+	T      time.Time
+	Proto  uint16
+	Method uint32
+	CallID uint32
+	Body   string // first 64 hex chars of body
+}
+
+func (t *rmcTrace) push(proto uint16, method uint32, callID uint32, body []byte) {
+	copy(t[:], t[1:])
+	n := len(body)
+	if n > 32 {
+		n = 32
+	}
+	t[len(t)-1] = struct {
+		T      time.Time
+		Proto  uint16
+		Method uint32
+		CallID uint32
+		Body   string
+	}{time.Now(), proto, method, callID, fmt.Sprintf("%x", body[:n])}
+}
+
 type Matchmaking struct {
 	// FindByParticipantEnabled fait répondre RÉELLEMENT à FindMatchmakeSessionByParticipant
 	// (0x6D.0x33) au lieu d'une liste vide. Animal Crossing s'en sert pour la visite d'île
@@ -121,6 +145,15 @@ type Matchmaking struct {
 	// entre amis (méthodes 9/10/13). nil = aucun ami, donc listes vides : le comportement
 	// des jeux qui n'utilisent pas ce mécanisme.
 	FriendPIDs func(pid uint64) []uint64
+	// FriendName fournit le nom affichable d'un ami, pour les éléments de la réponse de
+	// la méthode 15 (le client les montre dans le menu « avec amis »). nil = chaîne vide.
+	FriendName func(pid uint64) string
+	// OnFriendSessionCreated, quand il est défini, est appelé juste après que l'hôte a
+	// créé une session (0x26) avec (pid de l'hôte, gid). Les jeux dont le client
+	// n'appelle jamais UpdateNotificationData (0x6D/9) lui-même (LM3) s'en servent pour
+	// publier la donnée « salle ouverte » de l'hôte pour ses amis (m10/m13). nil par
+	// défaut : les jeux qui publient eux-mêmes (ACNH) restent inchangés.
+	OnFriendSessionCreated func(pid uint64, gid uint32)
 
 	notif      *notifStore
 	mu         sync.Mutex
@@ -128,11 +161,42 @@ type Matchmaking struct {
 	byCode     map[string]uint32
 	nextGID    uint32
 	codeRand   uint32
+	trace      map[uint64]*rmcTrace // per-PID RMC call history
+}
+
+// TraceCall records an RMC call in the per-PID ring.
+func (m *Matchmaking) TraceCall(pid uint64, proto uint16, method uint32, callID uint32, body []byte) {
+	m.mu.Lock()
+	t := m.trace[pid]
+	if t == nil {
+		t = &rmcTrace{}
+		m.trace[pid] = t
+	}
+	m.mu.Unlock()
+	t.push(proto, method, callID, body)
+}
+
+// dumpTrace prints the last N RMC calls for a PID.
+func (m *Matchmaking) dumpTrace(pid uint64) string {
+	m.mu.Lock()
+	t := m.trace[pid]
+	m.mu.Unlock()
+	if t == nil {
+		return "(no trace)"
+	}
+	var out string
+	for _, e := range t {
+		if e.T.IsZero() {
+			continue
+		}
+		out += fmt.Sprintf("\n  %s proto=%#x method=%d call=%d body=%s", e.T.Format("15:04:05.000"), e.Proto, e.Method, e.CallID, e.Body)
+	}
+	return out
 }
 
 // NewMatchmaking returns an empty store.
 func NewMatchmaking() *Matchmaking {
-	return &Matchmaking{gatherings: map[uint32]*gathering{}, byCode: map[string]uint32{}, nextGID: 1, codeRand: 0x1234, notif: newNotifStore()}
+	return &Matchmaking{gatherings: map[uint32]*gathering{}, byCode: map[string]uint32{}, nextGID: 1, codeRand: 0x1234, notif: newNotifStore(), trace: map[uint64]*rmcTrace{}}
 }
 
 // ExtensionHandler handles MatchmakeExtension (0x6D).
@@ -170,6 +234,8 @@ func (m *Matchmaking) ExtensionHandler() RMCHandler {
 			return m.getFriendNotificationData(conn, req, false)
 		case MethodGetFriendNotificationDataList:
 			return m.getFriendNotificationData(conn, req, true)
+		case MethodGetFriendNotificationDataByPID:
+			return m.getFriendNotificationDataByPID(conn, req)
 		case MethodUpdateMatchmakeSessionPart:
 			return m.updateSessionPart(conn, req)
 		case MethodUpdateApplicationBuffer:
@@ -204,6 +270,8 @@ func (m *Matchmaking) ExtensionHandler() RMCHandler {
 // MatchMakingHandler handles MatchMaking (0x15).
 func (m *Matchmaking) MatchMakingHandler() RMCHandler {
 	return func(conn *Connection, req *RMCMessage) *RMCMessage {
+		m.TraceCall(conn.PID, req.Protocol, req.Method, req.CallID, req.Body)
+		fmt.Printf("[0x15] pid=%d method=%d call=%d body=%x\n", conn.PID, req.Method, req.CallID, req.Body)
 		switch req.Method {
 		case MethodGetSessionURLs:
 			return m.getSessionURLs(conn, req)
@@ -337,14 +405,34 @@ func finalizeCreatedSession(session *MatchmakeSession, gid uint32, ownerPID uint
 	session.SessionKey = randomBytes(32)
 	session.StartedTime = NowDateTime()
 	session.SystemPasswordEnabled = false
+	session.UserPasswordEnabled = false
+	session.State = 1 // Open/Active
+	session.OpenParticipation = true // Host can be found by joiners
 	for len(session.Attribs) < 6 {
 		session.Attribs = append(session.Attribs, 0)
 	}
 	if session.Param.Params == nil {
 		session.Param.Params = map[string]Variant{}
 	}
-	session.Param.Params["@SR"] = Variant{Type: VariantBool, Bool: true}
-	session.Param.Params["@GIR"] = Variant{Type: VariantInt64, Int: 3}
+	// Strip empty-key entries that arise from NUL-terminated key serialization.
+	for k := range session.Param.Params {
+		if k == "" || k == "\x00" {
+			delete(session.Param.Params, k)
+		}
+	}
+	lm3SessionParams := map[string]Variant{
+		"@UsGI": {Type: VariantBool, Bool: true},
+		"@UpGI": {Type: VariantBool, Bool: true},
+		"@CC":   {Type: VariantUint64, Uint: 0},
+		"@RV":   {Type: VariantUint64, Uint: 1},
+		"@DR":   {Type: VariantUint64, Uint: 0},
+		"@VR":   {Type: VariantUint64, Uint: 34}, // match appVersion 0x22 from ApplicationData
+		"@TS":   {Type: VariantUint64, Uint: 8},
+		"@SR":   {Type: VariantBool, Bool: true},
+	}
+	for k, v := range lm3SessionParams {
+		session.Param.Params[k] = v
+	}
 }
 
 // createGathering registers a new gathering owned by the caller (mutex held).
@@ -384,7 +472,7 @@ func (m *Matchmaking) notifyParticipation(caller *Connection, participants []uin
 		}
 		SendNotification(target, &NotificationEvent{
 			PIDSource: caller.PID, Type: NotificationParticipate,
-			Param1: uint64(gid), Param2: caller.PID, StrParam: joinMessage, Param3: uint64(count),
+			Param1: uint64(gid), Param2: caller.PID, StrParam: participationStationData(caller.PID, participants, ep), Param3: uint64(count),
 		})
 	}
 	// 2. Recap to the caller: each pre-existing participant.
@@ -393,12 +481,33 @@ func (m *Matchmaking) notifyParticipation(caller *Connection, participants []uin
 			continue
 		}
 		SendNotification(caller, &NotificationEvent{
-			PIDSource: caller.PID, Type: NotificationParticipate,
-			Param1: uint64(gid), Param2: pid, StrParam: joinMessage, Param3: uint64(count),
+			PIDSource: pid, Type: NotificationParticipate,
+			Param1: uint64(gid), Param2: pid, StrParam: participationStationData(pid, participants, ep), Param3: uint64(count),
 		})
 	}
-	fmt.Printf("[MM] participation gid=%d caller=%d -> announce to %d participant(s) + recap %d existing (participants=%v)\n",
-		gid, caller.PID, count, count-1, participants)
+	fmt.Printf("[%s] [MM] participation gid=%d caller=%d -> announce to %d participant(s) + recap %d existing (participants=%v)\n",
+		ts(), gid, caller.PID, count, count-1, participants)
+}
+
+// participationStationData is the compact station-id list consumed by S2's Pia mesh
+// notification handler. Param2 carries the participant PID; these entries carry the
+// corresponding server connection IDs (RVCIDs) used by NAT traversal.
+func participationStationData(first uint64, participants []uint64, endpoint *Endpoint) string {
+	ids := [4]uint64{first}
+	if connection := endpoint.FindConnectionByPID(first); connection != nil {
+		ids[0] = uint64(connection.ID)
+	}
+	count := 1
+	for _, pid := range participants {
+		if pid == first || count == len(ids) {
+			continue
+		}
+		if connection := endpoint.FindConnectionByPID(pid); connection != nil {
+			ids[count] = uint64(connection.ID)
+		}
+		count++
+	}
+	return fmt.Sprintf("0x%016x:%016x:%016x:%016x", ids[0], ids[1], ids[2], ids[3])
 }
 
 // [Nextendo] NAT-aware matchmaking. A symmetric-mapping ("Strict") NAT cannot hole-punch to
@@ -488,6 +597,7 @@ func gatheringNATCompatible(ep *Endpoint, joiner natClass, members []uint64, joi
 
 func (m *Matchmaking) autoMatchmake(conn *Connection, req *RMCMessage) *RMCMessage {
 	s := conn.Settings
+	fmt.Printf("[%s] [MM] autoMatchmake request body=%x\n", ts(), req.Body)
 	var param AutoMatchmakeParam
 	in := NewStreamIn(req.Body, s)
 	in.Extract(&param)
@@ -525,7 +635,6 @@ func (m *Matchmaking) autoMatchmake(conn *Connection, req *RMCMessage) *RMCMessa
 			}
 		}
 	}
-	joined := false
 	if g == nil {
 		g = m.createGathering(conn, src)
 		if soloForced {
@@ -539,22 +648,39 @@ func (m *Matchmaking) autoMatchmake(conn *Connection, req *RMCMessage) *RMCMessa
 		}
 	} else if !containsPID(g.participants, conn.PID) {
 		g.participants = append(g.participants, conn.PID)
-		joined = true
 	}
 	g.session.NumParticipants = uint32(len(g.participants))
 	result := *g.session
+	// Deep-copy the param map so we don't mutate the persistent session.
+	if result.Param.Params != nil {
+		cp := make(map[string]Variant, len(result.Param.Params))
+		for k, v := range result.Param.Params {
+			cp[k] = v
+		}
+		result.Param.Params = cp
+	}
+	// finalizeCreatedSession already stamped all session params.
 	gid, count := g.session.ID, len(g.participants)
-	parts := append([]uint64(nil), g.participants...)
+	parts := make([]uint64, len(g.participants))
+	copy(parts, g.participants)
 	out := NewStreamOut(s)
 	out.Add(&result)
 	m.mu.Unlock()
 
-	fmt.Printf("[MM] autoMatchmake pid=%d -> gid=%d owner=%d host=%d joined=%v count=%d mode=%d flags=%d state=%d minP=%d maxP=%d skLen=%d attribs=%v respLen=%d\n  resp=%x\n",
-		conn.PID, gid, result.OwnerPID, result.HostPID, joined, count, result.GameMode, result.Flags, result.State, result.MinParticipants, result.MaxParticipants, len(result.SessionKey), result.Attribs, len(out.Bytes()), out.Bytes())
-	// Always notify the owner of the participation — including the lone-host self-join
-	// (joined==false), which is the case Pia needs to leave the WaitNotification wall.
-	_ = joined
+	// Self-notify the host (same as createSession) so the host leaves Pia's
+	// WaitNotification wall instead of hanging on "could not join game".
 	m.notifyParticipation(conn, parts, gid, "")
+
+	keys := make([]string, 0, len(result.Param.Params))
+	for k := range result.Param.Params {
+		keys = append(keys, k)
+	}
+	paramDump := ""
+	for k, v := range result.Param.Params {
+		paramDump += fmt.Sprintf(" %s=%+v", k, v)
+	}
+	fmt.Printf("[%s] [MM] autoMatchmake pid=%d -> gid=%d owner=%d host=%d count=%d mode=%d flags=%d state=%d open=%t minP=%d maxP=%d skLen=%d attribs=%v appDataLen=%d appData=%x paramKeys=%v params=[%s] respLen=%d\n  resp=%x\n",
+		ts(), conn.PID, gid, result.OwnerPID, result.HostPID, count, result.GameMode, result.Flags, result.State, result.OpenParticipation, result.MinParticipants, result.MaxParticipants, len(result.SessionKey), result.Attribs, len(result.ApplicationData), result.ApplicationData, keys, paramDump, len(out.Bytes()), out.Bytes())
 	return NewRMCSuccess(s, ProtocolMatchmakeExtension, req.Method, req.CallID, out.Bytes())
 }
 
@@ -577,6 +703,9 @@ func (m *Matchmaking) createSession(conn *Connection, req *RMCMessage) *RMCMessa
 	m.mu.Unlock()
 
 	fmt.Printf("[MM] createSession pid=%d -> gid=%d owner=%d\n", conn.PID, result.ID, result.OwnerPID)
+	if m.OnFriendSessionCreated != nil {
+		m.OnFriendSessionCreated(conn.PID, gid)
+	}
 	// Self-notify the host (same as autoMatchmake) so a friend-room/tournament lobby
 	// held solo also leaves Pia's WaitNotification wall instead of 2618-562.
 	m.notifyParticipation(conn, parts, gid, "")
@@ -860,7 +989,7 @@ func (m *Matchmaking) answerSessionURLsWhenHostIsReady(conn *Connection, req *RM
 		time.Sleep(hostReplaceURLPoll)
 
 		if urls, status := natBridgeStations(host.Stations(), m.PublicStationFirst); status == bridgeOK {
-			fmt.Printf("[MM] GetSessionURLs pid=%d: host reported its ReplaceURL -> bridged\n", conn.PID)
+			fmt.Printf("[%s] [MM] GetSessionURLs pid=%d: host reported its ReplaceURL -> bridged\n", ts(), conn.PID)
 			conn.SendRMC(sessionURLsResponse(conn, req, urls))
 
 			return
@@ -869,7 +998,7 @@ func (m *Matchmaking) answerSessionURLsWhenHostIsReady(conn *Connection, req *RM
 
 	// Out of time: answer with whatever the host reported. Not answering at all would
 	// leave the joiner hanging until ITS timeout, which is strictly worse.
-	fmt.Printf("[MM] GetSessionURLs pid=%d: host never reported its ReplaceURL -> raw stations\n", conn.PID)
+	fmt.Printf("[%s] [MM] GetSessionURLs pid=%d: host never reported its ReplaceURL -> raw stations\n", ts(), conn.PID)
 	conn.SendRMC(sessionURLsResponse(conn, req, host.Stations()))
 }
 
@@ -887,20 +1016,26 @@ func (m *Matchmaking) unregister(conn *Connection, req *RMCMessage) {
 	g, existed := m.gatherings[gid]
 	var owner uint64
 	mine := false
+	snapshot := "(none)"
 	if existed {
 		owner = g.session.OwnerPID
 		mine = owner == conn.PID
+		snapshot = fmt.Sprintf("state=%d mode=%d flags=%d open=%t minP=%d maxP=%d parts=%d partsList=%v started=%s",
+			g.session.State, g.session.GameMode, g.session.Flags, g.session.OpenParticipation,
+			g.session.MinParticipants, g.session.MaxParticipants, len(g.participants), g.participants,
+			time.Unix(int64(g.session.StartedTime), 0).Format(time.TimeOnly))
 	}
-	// [MC churn diag] Only the OWNER may unregister their gathering. A caller unregistering
-	// a gathering it does not own would silently delete another player's live lobby (making
-	// it un-browsable) — never legitimate. Log every call to see whether MC is tearing down
-	// its OWN just-created host session (the suspected churn cause).
 	if existed && mine {
 		delete(m.gatherings, gid)
+		// L'hôte a refermé sa salle : sa « porte ouverte » ne doit pas survivre à la
+		// session, sinon elle resterait proposée à ses amis (salle fantôme au m13).
+		m.notif.forget(owner)
 	}
 	m.mu.Unlock()
-	fmt.Printf("[MM] unregister caller=%d gid=%d existed=%v owner=%d mine=%v -> %s\n",
-		conn.PID, gid, existed, owner, mine, map[bool]string{true: "REMOVED", false: "kept (not owner / gone)"}[existed && mine])
+	trace := m.dumpTrace(conn.PID)
+	fmt.Printf("[%s] [MM] unregister caller=%d gid=%d existed=%v owner=%d mine=%v session=[%s] -> %s\n  last-RMC:%s\n",
+		ts(), conn.PID, gid, existed, owner, mine, snapshot,
+		map[bool]string{true: "REMOVED", false: "kept (not owner / gone)"}[existed && mine], trace)
 }
 
 // setParticipation implements MatchmakeExtension CloseParticipation(0x01) /
@@ -1146,9 +1281,14 @@ func (m *Matchmaking) endParticipation(conn *Connection, req *RMCMessage) {
 	gid := NewStreamIn(req.Body, conn.Settings).U32()
 	m.mu.Lock()
 	if g := m.gatherings[gid]; g != nil {
+		owner := g.session.OwnerPID
 		g.participants = removePID(g.participants, conn.PID)
 		if len(g.participants) == 0 {
 			delete(m.gatherings, gid)
+			// L'hôte a quitté en dernier : sa salle fermée ne doit plus apparaître au m13.
+			if owner == conn.PID {
+				m.notif.forget(owner)
+			}
 		} else {
 			g.session.NumParticipants = uint32(len(g.participants))
 		}
@@ -1172,6 +1312,26 @@ func (m *Matchmaking) makeCode(gid uint32) string {
 		g.code = code
 	}
 	return code
+}
+
+// SessionByPID returns the participant PID list for the gathering the given PID
+// is in, or nil if the PID is not in any gathering. Must NOT hold m.mu.
+func (m *Matchmaking) SessionByPID(pid uint64) []uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, g := range m.gatherings {
+		if g == nil || g.session == nil {
+			continue
+		}
+		for _, p := range g.participants {
+			if p == pid {
+				out := make([]uint64, len(g.participants))
+				copy(out, g.participants)
+				return out
+			}
+		}
+	}
+	return nil
 }
 
 func containsPID(list []uint64, pid uint64) bool {

--- a/matchmaking_notifdata.go
+++ b/matchmaking_notifdata.go
@@ -29,6 +29,18 @@ const (
 	MethodGetFriendNotificationData uint32 = 10
 	// MethodGetFriendNotificationDataList : données des amis pour PLUSIEURS types.
 	MethodGetFriendNotificationDataList uint32 = 13
+	// MethodGetFriendNotificationDataByPID : détails des amis signalés par les événements
+	// de classe 128 (le client appelle cette méthode avec les PID des événements 128xxx).
+	MethodGetFriendNotificationDataByPID uint32 = 15
+)
+
+// Classes d'événements reconnues par le client LM3 (vérifiées dans le binaire, m13
+// handler sub_7100EBF9C0) : un événement n'est retenu que si type/1000 vaut 111
+// (PID alimente directement la liste d'amis) ou 128 (le client repart chercher des
+// détails via la méthode 15). Tout autre type — 101..108, 4000..4999 — est ignoré.
+const (
+	EventClassFriendPlaying uint32 = 111000 // type/1000 == 111
+	EventClassFriendDetail  uint32 = 128000 // type/1000 == 128
 )
 
 // notifStore conserve, par joueur et par type, la dernière donnée de notification publiée.
@@ -125,6 +137,16 @@ func (m *Matchmaking) pushNotifDataToFriends(conn *Connection, ev *NotificationE
 	}
 }
 
+// PublishNotification enregistre une donnée de notification sous (pid, type) : c'est ce
+// que m10/m13 renvoie aux AMIS de pid. Exporté pour que le jeu construise ses propres
+// événements (layout « salle ouverte ») quand il publie pour son compte.
+func (m *Matchmaking) PublishNotification(pid uint64, typ uint32, ev *NotificationEvent) {
+	if ev == nil {
+		return
+	}
+	m.notif.put(pid, typ, ev)
+}
+
 // friendNotificationsFor collecte les données publiées par les AMIS de l'appelant pour les
 // types demandés. Sans source de liste d'amis configurée, la réponse est vide — c'est-à-dire
 // le comportement qu'avait le cœur avant ce fichier, donc rien ne change pour les autres jeux.
@@ -133,26 +155,41 @@ func (m *Matchmaking) friendNotificationsFor(pid uint64, types []uint32) []*Noti
 		return nil
 	}
 	var out []*NotificationEvent
+	// Un même (ami, type) ne doit pas revenir en double quand plusieurs kinds de la
+	// requête 101..108 pointent vers le même événement.
+	seen := map[uint64]map[uint32]bool{}
+	add := func(friend uint64, ev *NotificationEvent) {
+		if ev == nil || ev.Param2 == 0 {
+			return
+		}
+		if seen[friend] == nil {
+			seen[friend] = map[uint32]bool{}
+		}
+		if seen[friend][ev.Type] {
+			return
+		}
+		seen[friend][ev.Type] = true
+		out = append(out, ev)
+	}
 	for _, friend := range m.FriendPIDs(pid) {
 		for _, typ := range types {
-			ev := m.notif.get(friend, typ)
-			if ev == nil {
+			if ev := m.notif.get(friend, typ); ev != nil {
+				add(friend, ev)
 				continue
 			}
-			// Filtre « porte ouverte ». Mesuré sur le stack de référence : dans la donnée de
-			// notification ACNH, Param2 vaut 1 quand l'aéroport est OUVERT, 0 quand il est
-			// fermé (l'hôte republie une donnée Param2=0 en fermant sa porte sans se
-			// déconnecter). Un hôte fermé ne doit pas figurer au menu de visite.
-			if ev.Param2 == 0 {
-				continue
+			if typ >= 101 && typ <= 108 {
+				// LM3 : le client interroge les kinds 101..108, mais son gestionnaire
+				// m13 (sub_7100EBF9C0) ne retient que les événements dont type/1000
+				// vaut 111 ou 128 — 111 alimente directement la liste d'amis, 128
+				// déclenche un aller-retour méthode 15. Les deux classes sont publiées
+				// sous LM3_FRIEND_EVENT_TYPE ; on les sert toutes les deux ici.
+				add(friend, m.notif.get(friend, EventClassFriendPlaying))
+				add(friend, m.notif.get(friend, EventClassFriendDetail))
 			}
-			out = append(out, ev)
 		}
 	}
 	return out
 }
-
-// getFriendNotificationData répond aux méthodes 10 (un type) et 13 (plusieurs types).
 func (m *Matchmaking) getFriendNotificationData(conn *Connection, req *RMCMessage, list bool) *RMCMessage {
 	s := conn.Settings
 	in := NewStreamIn(req.Body, s)
@@ -169,10 +206,25 @@ func (m *Matchmaking) getFriendNotificationData(conn *Connection, req *RMCMessag
 
 	events := m.friendNotificationsFor(conn.PID, types)
 
+	// Layout des événements m13, piné dans le binaire (sub_7100E95B40) : chaque
+	// élément porte un en-tête [u8 version][u32 longueur] puis ses champs, et le
+	// string est préfixé par u16 (sub_7100E90F40). Le lecteur saute à la fin de
+	// l'élément via version+len. On sérialise donc À LA MAIN, sans passer par le
+	// writer de structures (dont le préfixe de string u32 désalignerait la trame) :
+	//   [u8 0][u32 len=38+strlen][pid u64][type u32][p1 u64][p2 u64][str u16][p3 u64]
 	out := NewStreamOut(s)
 	out.U32(uint32(len(events)))
 	for _, ev := range events {
-		out.Add(ev)
+		contentLen := 8 + 4 + 8 + 8 + 2 + len(ev.StrParam) + 8
+		out.U8(0)
+		out.U32(uint32(contentLen))
+		out.U64(ev.PIDSource)
+		out.U32(ev.Type)
+		out.U64(ev.Param1)
+		out.U64(ev.Param2)
+		out.U16(uint16(len(ev.StrParam)))
+		out.Write([]byte(ev.StrParam))
+		out.U64(ev.Param3)
 	}
 	fmt.Printf("[MM] notifications d'amis pid=%d types=%v -> %d entrée(s)\n", conn.PID, types, len(events))
 	resp := NewRMCSuccess(s, ProtocolMatchmakeExtension, req.Method, req.CallID, out.Bytes())
@@ -186,4 +238,33 @@ func (m *Matchmaking) getFriendNotificationData(conn *Connection, req *RMCMessag
 		})
 	}
 	return resp
+}
+
+// getFriendNotificationDataByPID répond à la méthode 15 : le client l'appelle avec les PID
+// des amis signalés par les événements de classe 128. Le parseur client (sub_7100E95E00)
+// lit [u32 count], puis par objet : une chaîne u16-préfixée et un « Any » (u8 tag + valeur,
+// sub_7100E91210). On renvoie { nom affichable, tag 1 + PID } par ami demandé.
+func (m *Matchmaking) getFriendNotificationDataByPID(conn *Connection, req *RMCMessage) *RMCMessage {
+	s := conn.Settings
+	in := NewStreamIn(req.Body, s)
+	pids := ReadList(in, func(i *StreamIn) uint64 { return i.PID() })
+	_ = in.Buffer()
+	if in.Err() != nil {
+		return NewRMCError(s, ProtocolMatchmakeExtension, req.CallID, ResultCoreInvalidArgument)
+	}
+
+	out := NewStreamOut(s)
+	out.U32(uint32(len(pids)))
+	for _, p := range pids {
+		name := ""
+		if m.FriendName != nil {
+			name = m.FriendName(p)
+		}
+		out.U16(uint16(len(name)))
+		out.Write([]byte(name))
+		out.U8(1) // Any tag 1 = entier 64 bits
+		out.U64(p)
+	}
+	fmt.Printf("[MM] notification data pid=%d amis=%v -> %d entrée(s)\n", conn.PID, pids, len(pids))
+	return NewRMCSuccess(s, ProtocolMatchmakeExtension, req.Method, req.CallID, out.Bytes())
 }

--- a/natbridge.go
+++ b/natbridge.go
@@ -2,6 +2,7 @@ package nex
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -63,6 +64,102 @@ var (
 )
 
 const natCacheTTL = 2 * time.Second
+
+// Relay state: when the game server enables it (SetStationRelay), the natbridge hands
+// out station URLs at the server's relay socket instead of the host's observed endpoint.
+// The relay port forwards the traffic between the two peers, which is the only way two
+// NAT'd players with no port forwarding can talk at all.
+var (
+	relayMu   sync.RWMutex
+	relayHost string
+	relayPort int
+)
+
+// SetStationRelay switches the natbridge into relay mode: GetSessionURLs answers with
+// stations at the server's relay socket (host:port) so ALL of a joiner's station
+// traffic — resolve probes, punch attempts, data — lands on the relay port, and the
+// game server forwards it to the real peer there. Pass host "" to disable.
+func SetStationRelay(host string, port int) {
+	relayMu.Lock()
+	defer relayMu.Unlock()
+	relayHost = host
+	relayPort = port
+}
+
+// StationRelay reports the relay mode configuration (host, port, enabled).
+func StationRelay() (string, int, bool) {
+	relayMu.RLock()
+	defer relayMu.RUnlock()
+	return relayHost, relayPort, relayHost != "" && relayPort > 0
+}
+
+// stationRelay is the internal form of StationRelay.
+func stationRelay() (string, int, bool) {
+	return StationRelay()
+}
+
+// NatPortForIP returns the external UDP port the nncs responder observed for a
+// public IP — the endpoint peers must actually send station traffic to. Exported
+// for game servers that shape 0x79 station records (LM3) off the station list.
+func NatPortForIP(ip string) (int, bool) {
+	return natPortForIP(ip)
+}
+
+// bestStationURL returns the station URL a peer should be told to probe for the
+// given connection: the relay socket in relay mode; otherwise the station on the
+// NNCS-confirmed UDP port (the endpoint the NAT check actually observed —
+// ReplaceURL's post-NAT station carries it); otherwise the public-flagged
+// station, else the first station. It is the URL the NAT traversal handler
+// pushes in an InitiateProbe when the requesting console (m=1) did not supply
+// its own station URL.
+func bestStationURL(conn *Connection) string {
+	if conn == nil {
+		return ""
+	}
+	if rHost, rPort, rOn := stationRelay(); rOn {
+		for _, u := range conn.Stations() {
+			if u != nil && u.Get("address") == rHost && u.GetInt("port") == rPort {
+				return u.String()
+			}
+		}
+	}
+	natPort := 0
+	if host, _, err := net.SplitHostPort(conn.RemoteAddr); err == nil {
+		if p, ok := natPortForIP(host); ok {
+			natPort = p
+		}
+	}
+	var fallback string
+	var natfURL string
+	var pubURL string
+	for _, u := range conn.Stations() {
+		if u == nil || u.Get("address") == "" {
+			continue
+		}
+		if natPort > 0 && u.GetInt("port") == natPort {
+			return u.String()
+		}
+		if fallback == "" {
+			fallback = u.String()
+		}
+		// A station carrying natf was re-reported AFTER the NAT handshake
+		// (ReplaceURL) — it is the one with the confirmed endpoint. Prefer it
+		// over a public-flagged station, which may still carry the WSS TCP port.
+		if u.GetInt("natf") != 0 && natfURL == "" {
+			natfURL = u.String()
+		}
+		if u.GetInt("type")&2 != 0 && pubURL == "" {
+			pubURL = u.String()
+		}
+	}
+	if natfURL != "" {
+		return natfURL
+	}
+	if pubURL != "" {
+		return pubURL
+	}
+	return fallback
+}
 
 // natPortForIP returns the external UDP port the nncs responder observed for a public IP.
 func natPortForIP(ip string) (int, bool) {
@@ -137,6 +234,44 @@ func natBridgeStations(urls []*StationURL, publicFirst bool) ([]*StationURL, bri
 		return urls, bridgeNoStations
 	}
 
+	// The RVCID comes from the host's ReplaceURL, sent AFTER its NAT handshake. This is the
+	// one shortfall worth waiting on: the host is expected to report it within about a
+	// second, and a joiner routinely asks before it does.
+	cid := local.GetInt("RVCID")
+	if cid == 0 {
+		return urls, bridgeNoRVCID
+	}
+
+	if relayHost, relayPort, relayOn := stationRelay(); relayOn {
+		// Relay mode: the host's stored public station already points at the server's
+		// relay socket (Register rewrote it), and the joiner could never reach the
+		// host's real endpoint anyway (no port forwarding on either side). Hand out
+		// relay URLs for BOTH candidates so every packet — resolve probe, punch,
+		// data — lands on the relay port, where the server forwards by destination
+		// connection id (seeded with the host's observed UDP endpoint). The LAN
+		// candidate keeps natf=34;natm=1 so the console treats it as directly
+		// reachable and connects without a punch dance.
+		lan := public.Copy()
+		lan.Set("address", relayHost)
+		lan.SetInt("port", relayPort)
+		lan.SetInt("RVCID", cid)
+		lan.Set("natf", "34")
+		lan.Set("natm", "1")
+		lan.Remove("type")
+		lan.Remove("Pa")
+
+		pub := public.Copy()
+		pub.Set("address", relayHost)
+		pub.SetInt("port", relayPort)
+		pub.SetInt("type", int(StationURLFlagBehindNAT|StationURLFlagPublic|stationURLFlagSwitch))
+		pub.Set("Pa", privateAddr)
+
+		fmt.Printf("[%s] [natbridge] relay mode: %s stations -> relay %s:%d (lan=%s rvcid=%d)\n",
+			ts(), publicAddr, relayHost, relayPort, privateAddr, cid)
+
+		return []*StationURL{lan, pub}, bridgeOK
+	}
+
 	udpPort, ok := natPortForIP(publicAddr)
 	if !ok {
 		// The nncs responder never saw this host. Either it has not probed yet, or its
@@ -145,14 +280,6 @@ func natBridgeStations(urls []*StationURL, publicFirst bool) ([]*StationURL, bri
 		natBridgeSkip("no nncs observation for "+publicAddr, urls)
 
 		return urls, bridgeNoObservation
-	}
-
-	// The RVCID comes from the host's ReplaceURL, sent AFTER its NAT handshake. This is the
-	// one shortfall worth waiting on: the host is expected to report it within about a
-	// second, and a joiner routinely asks before it does.
-	cid := local.GetInt("RVCID")
-	if cid == 0 {
-		return urls, bridgeNoRVCID
 	}
 
 	// La station LAN se construit à partir de la station LOCALE de l'hôte (son ReplaceURL), PAS de
@@ -187,8 +314,8 @@ func natBridgeStations(urls []*StationURL, publicFirst bool) ([]*StationURL, bri
 	// between a joinable host and a session that stalls at MatchMakingExt m=1, and it
 	// depends on a file written by another process — so it must be visible in the log
 	// rather than inferred from players reporting that it works.
-	fmt.Printf("[natbridge] %s: registered tcp port %d -> observed udp port %d (lan=%s rvcid=%d, publicFirst=%v)\n",
-		publicAddr, public.GetInt("port"), udpPort, privateAddr, cid, publicFirst)
+	fmt.Printf("[%s] [natbridge] %s: registered tcp port %d -> observed udp port %d (lan=%s rvcid=%d, publicFirst=%v)\n",
+		ts(), publicAddr, public.GetInt("port"), udpPort, privateAddr, cid, publicFirst)
 
 	// Station order. MK8/S2 take [lan, public] (the default). ACNH's Pia treats the FIRST
 	// station as the primary P2P candidate and never falls through to the second, so a
@@ -212,6 +339,6 @@ func natBridgeSkip(why string, urls []*StationURL) {
 		rendered = append(rendered, u.String())
 	}
 
-	fmt.Printf("[natbridge] SKIP (%s) — handing over raw stations: %s\n",
-		why, strings.Join(rendered, " | "))
+	fmt.Printf("[%s] [natbridge] SKIP (%s) — handing over raw stations: %s\n",
+		ts(), why, strings.Join(rendered, " | "))
 }

--- a/nattraversal.go
+++ b/nattraversal.go
@@ -1,6 +1,9 @@
 package nex
 
-import "fmt"
+import (
+	"fmt"
+	"net"
+)
 
 // NAT traversal protocol (P2P hole-punch coordination).
 const (
@@ -15,13 +18,20 @@ const (
 	MethodReportNATTraversalResultDetail uint32 = 0x7
 )
 
-// NATTraversalHandler coordinates the P2P hole-punch. The key method is
-// RequestProbeInitiationExt: when a client asks the server to have its peers
-// probe it back, we push an InitiateProbe request to each target carrying the
-// caller's own station URL, so BOTH ends fire UDP probes and open their NATs at
-// the same time. The stock flow opens only the joiner's NAT, leaving the other
-// console's Pia waiting ("communication error"). Every other method is a simple
-// acknowledgement (the actual hole-punch happens directly between the consoles).
+// NATTraversalHandler coordinates the P2P hole-punch. The punch is a two-way
+// chain (kinnay's documented Pia flow): console A calls RequestProbeInitiation
+// (m=1) or RequestProbeInitiationExt (m=3) naming its target; the server pushes
+// InitiateProbe (m=2) to that target carrying A's station URL; the target then
+// probes A directly AND calls m=1/m=3 back on the server; the server MUST push
+// InitiateProbe to A in turn, and only then does A probe the target. If either
+// push is dropped the corresponding console never fires a probe, the other end
+// never gets a reply, and its ReportNATTraversalResult fails with rtt=0 even
+// though both NATs are perfectly punchable.
+//
+// m=1 carries only the target list (no station URL), so the URL it pushes is
+// the caller's REGISTERED station; m=3 carries the caller's own station URL
+// (the endpoint its NAT check confirmed), which we push verbatim (rewritten to
+// the relay socket in relay mode).
 func NATTraversalHandler() RMCHandler {
 	return func(conn *Connection, req *RMCMessage) *RMCMessage {
 		switch req.Method {
@@ -73,35 +83,104 @@ func relaySignatureKey(conn *Connection, req *RMCMessage) *RMCMessage {
 
 // pushInitiateProbe relays a server→client InitiateProbe to every target the
 // caller named, carrying the caller's own station URL so each target probes back.
+//
+// The payload URL cannot be pushed verbatim: this client advertises its own
+// station in the payload as the GAME SERVER's address with its own
+// NAT-checked port (34.174.141.27:59472 in this deployment) — the address of
+// the server it is connected to, not an endpoint the target can reach. Pushing
+// that verbatim sends the punch at the server IP on a port nothing listens on,
+// and every probe dies there (rtt=0) even though both NATs are perfectly
+// punchable. So the pushed URL is the payload repointed at the endpoint the
+// server actually observes: the caller's real IP and the UDP port the nncs
+// responder confirmed (the relay socket in relay mode). Every other parameter
+// (RVCID, PID, CID, natf, probeinit, type) is preserved.
 func pushInitiateProbe(conn *Connection, req *RMCMessage) {
 	s := conn.Settings
 	in := NewStreamIn(req.Body, s)
 	targetList := ReadList(in, func(i *StreamIn) string { return i.String() })
-	stationToProbe := in.String()
+	payloadURL := in.String()
 	if in.Err() != nil {
 		return
 	}
 
+	u := ParseStationURL(payloadURL)
+	if rHost, rPort, rOn := stationRelay(); rOn {
+		u.Set("address", rHost)
+		u.SetInt("port", rPort)
+	} else if host, _, err := net.SplitHostPort(conn.RemoteAddr); err == nil && !isPrivateIP(host) {
+		u.Set("address", host)
+		if p, ok := natPortForIP(host); ok {
+			u.SetInt("port", p)
+		}
+	}
+	pushed := u.String()
+
+	fmt.Printf("[NAT] pid=%d RequestProbeInitiationExt targets=%d payload=%s\n",
+		conn.PID, len(targetList), payloadURL)
+	fmt.Printf("[NAT] pid=%d push InitiateProbe -> station=%s\n", conn.PID, pushed)
+
 	// The InitiateProbe request body is a single station URL (the caller's).
 	probe := NewStreamOut(s)
-	probe.StationURL(ParseStationURL(stationToProbe))
-	probeBody := probe.Bytes()
+	probe.StationURL(ParseStationURL(pushed))
+	pushProbeToTargets(conn, req, targetList, probe.Bytes())
+}
 
+// pushInitiateProbeFromStored handles RequestProbeInitiation (m=1): the same
+// push as the Ext variant, but the request carries only the target list — no
+// station URL — so the pushed URL is the caller's REGISTERED station (the relay
+// socket in relay mode, else the endpoint the NAT check confirmed). This is the
+// call the target console makes when IT receives its push, and without this push
+// going out in turn the original caller never fires a single probe.
+func pushInitiateProbeFromStored(conn *Connection, req *RMCMessage) {
+	s := conn.Settings
+	in := NewStreamIn(req.Body, s)
+	targetList := ReadList(in, func(i *StreamIn) string { return i.String() })
+	if in.Err() != nil {
+		return
+	}
+
+	stationToProbe := bestStationURL(conn)
+	if stationToProbe == "" {
+		fmt.Printf("[NAT] pid=%d RequestProbeInitiation targets=%d NO station url, skip push\n",
+			conn.PID, len(targetList))
+
+		return
+	}
+
+	fmt.Printf("[NAT] pid=%d RequestProbeInitiation targets=%d stationToProbe=%s\n",
+		conn.PID, len(targetList), stationToProbe)
+
+	probe := NewStreamOut(s)
+	probe.StationURL(ParseStationURL(stationToProbe))
+	pushProbeToTargets(conn, req, targetList, probe.Bytes())
+}
+
+// pushProbeToTargets sends the InitiateProbe push (body already built) to every
+// target in the list, resolved by RVCID (falling back to PID). Server-initiated
+// requests use a distinct call-id space.
+func pushProbeToTargets(conn *Connection, req *RMCMessage, targetList []string, probeBody []byte) {
+	s := conn.Settings
 	for _, raw := range targetList {
-		rvcid := uint32(ParseStationURL(raw).GetInt("RVCID"))
-		if rvcid == 0 {
-			fmt.Printf("[NAT/diag] pushInitiateProbe caller=%d: cible sans RVCID (%q) — IGNORÉE\n", conn.PID, raw)
-			continue
+		u := ParseStationURL(raw)
+		rvcid := uint32(u.GetInt("RVCID"))
+		var target *Connection
+		if rvcid != 0 {
+			target = conn.Endpoint.FindConnectionByID(rvcid)
 		}
-		target := conn.Endpoint.FindConnectionByID(rvcid)
+		if target == nil {
+			if pid := uint64(u.GetInt("PID")); pid != 0 {
+				target = conn.Endpoint.FindConnectionByPID(pid)
+			}
+		}
 		if target == nil {
 			fmt.Printf("[NAT/diag] pushInitiateProbe caller=%d: cible RVCID=%d INTROUVABLE — pas d'InitiateProbe\n", conn.PID, rvcid)
 			continue
 		}
 		// Server-initiated requests use a distinct call-id space.
 		fmt.Printf("[NAT/diag] pushInitiateProbe caller=%d -> InitiateProbe VERS pid=%d (id=%d rvcid=%d) station=%q\n",
-			conn.PID, target.PID, target.ID, rvcid, stationToProbe)
+			conn.PID, target.PID, target.ID, rvcid, string(probeBody))
 		target.SendRMC(NewRMCRequest(s, ProtocolNATTraversal, MethodInitiateProbe, 0xFFFF0000+req.CallID, probeBody))
+		fmt.Printf("[NAT] pid=%d push InitiateProbe -> cid=%d url=%s\n", conn.PID, target.ID, string(probeBody))
 	}
 }
 

--- a/notification.go
+++ b/notification.go
@@ -2,6 +2,7 @@ package nex
 
 import (
 	"crypto/rand"
+	"fmt"
 	"sync/atomic"
 )
 
@@ -64,6 +65,8 @@ var notifCallCounter uint32
 // (a hardcoded source port is silently dropped).
 func SendNotification(target *Connection, event *NotificationEvent) {
 	s := target.Settings
+	fmt.Printf("[NEX Notify] target=%d source=%d type=%d param1=%d param2=%d str=%q param3=%d\n",
+		target.PID, event.PIDSource, event.Type, event.Param1, event.Param2, event.StrParam, event.Param3)
 	out := NewStreamOut(s)
 	out.Add(event)
 	callID := 0xFFFE0000 + atomic.AddUint32(&notifCallCounter, 1)

--- a/rmc.go
+++ b/rmc.go
@@ -126,8 +126,8 @@ func ParseRMC(s *Settings, data []byte) (*RMCMessage, error) {
 // and AcquireNexUniqueIDWithPassword both stayed hidden for weeks, each breaking a subset of
 // players. A refusal is the single most interesting thing this server does; it gets a line.
 func notImplemented(conn *Connection, proto uint16, req *RMCMessage) *RMCMessage {
-	fmt.Printf("[NEX] UNHANDLED proto=0x%x method=%d (0x%x) pid=%d callID=%d bodyLen=%d\n",
-		proto, req.Method, req.Method, conn.PID, req.CallID, len(req.Body))
+	fmt.Printf("[NEX] UNHANDLED proto=0x%x method=%d (0x%x) pid=%d callID=%d body=%x\n",
+		proto, req.Method, req.Method, conn.PID, req.CallID, req.Body)
 
 	return NewRMCError(conn.Settings, proto, req.CallID, ResultCoreNotImplemented)
 }

--- a/secureconnection.go
+++ b/secureconnection.go
@@ -34,6 +34,32 @@ type SecureConnectionConfig struct {
 	// SetPa adds Pa=<address> to the public station. Pia 5.19 needs it to build the NAT
 	// probe; the proven S2 server sends NO Pa at all.
 	SetPa bool
+	// PublicHost is the server's own public IP (NEXTENDO_HOST). A host co-located with
+	// this server hairpins through its own router, so its probes arrive from a private
+	// address and its game reports a VPN-looking LAN address (Radmin/Hamachi/ZeroTier)
+	// as both local and public — a pair the natbridge cannot split, and a public
+	// candidate no peer can reach. When set, Register/ReplaceURL repoint such hosts at
+	// this address. Empty = no correction.
+	PublicHost string
+	// P2PAnchorPort is a fixed UDP port that stays bound, FORWARDED and RESPONDING for
+	// P2P probes (the nncs responder also serves it). The game's resolve job probes its
+	// station URLs with the same 16-byte probe format it uses on nncs, and S2 accepts
+	// the resolve only when every reply reports the SAME client source port (it never
+	// checks which IP the reply came from). A co-located host's own station — its
+	// VPN/LAN address — is unreachable or unresponsive, so the resolve never sees a
+	// consistent port and the host dies with 2618-201 after a few retry bursts. The
+	// anchor points the station at a port our responder answers, so the resolve always
+	// completes. 0 = disable (pass the host's own stations through, stock behaviour).
+	P2PAnchorPort int
+	// P2PRelay makes the server stand in for EVERY host's station — not just a
+	// co-located one. Register stores the public station at PublicHost:P2PAnchorPort
+	// (the server's relay socket) for all hosts, so every client's resolve probes,
+	// punch attempts and station traffic land on the relay port, which the game
+	// server forwards between peers. This is what connects two players who are both
+	// behind firewalled NATs with no port forwarding: neither can reach the other's
+	// real endpoint, but both can reach (and keep a NAT mapping toward) the server.
+	// Requires PublicHost and P2PAnchorPort to be set. Disabled by default.
+	P2PRelay bool
 }
 
 // SwitchPia519Config is what SSBU (Pia 5.19) needs: type=0x0B plus Pa.
@@ -68,7 +94,7 @@ func SecureConnectionHandlerWithConfig(cfg SecureConnectionConfig) RMCHandler {
 		case MethodRegister, MethodRegisterEx:
 			return handleRegister(conn, req, cfg)
 		case MethodReplaceURL:
-			return handleReplaceURL(conn, req)
+			return handleReplaceURLWithConfig(conn, req, cfg)
 		default:
 			return notImplemented(conn, ProtocolSecureConnection, req)
 		}
@@ -83,6 +109,16 @@ func handleRegister(conn *Connection, req *RMCMessage, cfg SecureConnectionConfi
 	local, public := selectStations(urls)
 	if local == nil {
 		local = NewStationURL("prudp")
+	}
+	// The Splatoon 2 client reports ONE station url — its LAN address — and this stack
+	// serves it for BOTH roles when that address does not look private (a VPN adapter):
+	// selectStations files the url under public, then the fallback picks the same
+	// pointer as local. A local/public pair that is the same OBJECT cannot be split by
+	// the natbridge (the addresses are identical), so Register must take the derived
+	// path: keep the url as local and synthesize a SEPARATE public copy. Without this
+	// the host's own NAT-keep sees a public station that matches nothing.
+	if local != nil && public != nil && (local == public || local.Get("address") == public.Get("address")) {
+		public = nil
 	}
 	// derivedPublic: the client reported no public station, so we synthesised one from
 	// the observed endpoint. It changes what Pa must be — see the Pa comment below.
@@ -131,12 +167,52 @@ func handleRegister(conn *Connection, req *RMCMessage, cfg SecureConnectionConfi
 	}
 
 	conn.SetStations([]*StationURL{local, public})
-	fmt.Printf("[Register] pid=%d -> local=%s\n           public=%s\n", conn.PID, local.String(), public.String())
+	fixStationEndpoint(conn, local, public, cfg)
+
+	if cfg.P2PRelay && cfg.PublicHost != "" {
+		// Relay mode: the server stands in for this host's station, so point the
+		// STORED public station at the relay socket. Everything downstream then
+		// inherits the relay address: the natbridge hands out relay URLs at
+		// GetSessionURLs, and the 0x79 station records (via Stations()) carry them
+		// too — so ALL of a peer's station traffic lands on the relay port.
+		if cfg.P2PAnchorPort > 0 {
+			public.SetInt("port", cfg.P2PAnchorPort)
+		}
+		public.Set("address", cfg.PublicHost)
+	}
+
+	// The station Pia's resolve job probes (the response) and the station peers get
+	// (stored, via the natbridge) must differ for a host co-located with this server.
+	// Its probes hairpin through its own router, so the observed endpoint is the
+	// router's LAN address — useless as a station for the host itself (192.168.1.1 is
+	// the router, nothing listens there) AND for peers. The response must point at an
+	// address the host can actually probe-and-get-a-reply-from, which for a co-located
+	// host is the server's own public IP (hairpin delivers it back to this LAN).
+	respPublic := public.Copy()
+	if host, _, err := net.SplitHostPort(conn.RemoteAddr); err == nil {
+		switch {
+		case cfg.P2PRelay && cfg.PublicHost != "":
+			// Relay mode: respPublic is already a copy of the relay-pointed public
+			// station — the client's resolve job probes the relay and gets answered.
+		case isPrivateIP(host) && cfg.PublicHost != "":
+			respPublic.Set("address", cfg.PublicHost)
+			if cfg.P2PAnchorPort > 0 {
+				respPublic.SetInt("port", cfg.P2PAnchorPort)
+			}
+		default:
+			respPublic.Set("address", host)
+			if p, ok := natPortForIP(host); ok {
+				respPublic.SetInt("port", p)
+			}
+		}
+	}
+	fmt.Printf("[%s] [Register] pid=%d -> local=%s\n           stored=%s\n           resp=%s\n",
+		ts(), conn.PID, local.String(), public.String(), respPublic.String())
 
 	out := NewStreamOut(s)
-	out.U32(ResultCoreUnknown)  // retval (success)
-	out.U32(conn.ID)            // pidConnectionID (RVCID)
-	out.String(public.String()) // urlPublic
+	out.U32(ResultCoreUnknown)      // retval (success)
+	out.U32(conn.ID)                // pidConnectionID (RVCID)
+	out.String(respPublic.String()) // urlPublic
 	return NewRMCSuccess(s, ProtocolSecureConnection, req.Method, req.CallID, out.Bytes())
 }
 
@@ -149,6 +225,10 @@ func handleRegister(conn *Connection, req *RMCMessage, cfg SecureConnectionConfi
 // by ADDRESS with the new url winning for its address (keeps the fresh LAN url,
 // removes stale duplicates), matching the proven server.
 func handleReplaceURL(conn *Connection, req *RMCMessage) *RMCMessage {
+	return handleReplaceURLWithConfig(conn, req, SecureConnectionConfig{})
+}
+
+func handleReplaceURLWithConfig(conn *Connection, req *RMCMessage, cfg SecureConnectionConfig) *RMCMessage {
 	s := conn.Settings
 	in := NewStreamIn(req.Body, s)
 	_ = in.StationURLValue() // target (the url being replaced) — unused; we dedupe by address
@@ -157,6 +237,25 @@ func handleReplaceURL(conn *Connection, req *RMCMessage) *RMCMessage {
 		return NewRMCSuccess(s, ProtocolSecureConnection, req.Method, req.CallID, nil)
 	}
 	newStation.SetInt("PID", int(conn.PID))
+	// The re-reported LAN url carries the same wrong VPN-looking address as Register did;
+	// repoint it so the dedupe keeps one local station the natbridge can pair with public.
+	fixStationAddressForEndpoint(conn, newStation, cfg)
+	// A REMOTE client re-reports its post-NAT LAN url (private address, real UDP port,
+	// RVCID) here. Store it pointing at the endpoint we actually observe — the private
+	// address is the one peers could never reach, and the port it carries is the one the
+	// NAT handshake confirmed. Register already does this for the public station; without
+	// it the host's ReplaceURL (192.168.0.20:58108 style) leaks into 0x79 station records
+	// and the joiner's direct mesh connection dies before it starts.
+	// In relay mode the observed IP is NOT what peers must reach (the server's relay
+	// socket is), so the LAN url stays as reported — it is the natbridge's local
+	// candidate and the source of the Pa value either way.
+	if !cfg.P2PRelay {
+		if host, _, err := net.SplitHostPort(conn.RemoteAddr); err == nil && !isPrivateIP(host) {
+			if a := newStation.Get("address"); a != host {
+				newStation.Set("address", host)
+			}
+		}
+	}
 	newAddr := newStation.Get("address")
 
 	byAddr := map[string]*StationURL{}
@@ -179,7 +278,7 @@ func handleReplaceURL(conn *Connection, req *RMCMessage) *RMCMessage {
 	}
 	conn.SetStations(rebuilt)
 
-	fmt.Printf("[ReplaceURL] pid=%d -> new=%s (now %d station(s))\n", conn.PID, newStation.String(), len(rebuilt))
+	fmt.Printf("[%s] [ReplaceURL] pid=%d -> new=%s (now %d station(s))\n", ts(), conn.PID, newStation.String(), len(rebuilt))
 	return NewRMCSuccess(s, ProtocolSecureConnection, req.Method, req.CallID, nil)
 }
 
@@ -232,4 +331,59 @@ func isPrivateIP(addr string) bool {
 	}
 
 	return ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || cgnatRange.Contains(ip)
+}
+
+// fixStationEndpoint repoints a host's registered stations so its resolve job and its
+// peers can actually probe them. Run AFTER SetStations so the [Register] log shows the
+// corrected shape.
+//
+// A host co-located with this server probes through its own router, so every probe
+// arrives from a PRIVATE address (hairpin). Its game reports the address of the
+// interface the emulator chose — often a VPN adapter (Radmin 26.x, Hamachi 25.x,
+// ZeroTier 172.28.x) — as BOTH its local and public station. That shape breaks the
+// natbridge two ways: the local/public pair is identical (selectStations files both
+// under public), and the address is one no peer can route to. When cfg.PublicHost is
+// set, we repoint public at the server's own public IP and local at the observed
+// hairpin source, restoring the distinct private/public pair the natbridge needs.
+func fixStationEndpoint(conn *Connection, local, public *StationURL, cfg SecureConnectionConfig) {
+	obsHost, _, err := net.SplitHostPort(conn.RemoteAddr)
+	if err != nil || obsHost == "" {
+		return
+	}
+
+	if isPrivateIP(obsHost) {
+		if cfg.PublicHost == "" {
+			return
+		}
+		public.Set("address", cfg.PublicHost)
+		if cfg.P2PAnchorPort > 0 {
+			public.SetInt("port", cfg.P2PAnchorPort)
+		}
+		if !isPrivateIP(local.Get("address")) {
+			local.Set("address", obsHost)
+		}
+		return
+	}
+
+	// Remote client: the public station must point at the endpoint we observed. A
+	// client that reported no public station already gets this in handleRegister's
+	// derivedPublic path; this also fixes clients that reported a VPN-looking
+	// address as their public one.
+	if pa := public.Get("address"); pa != obsHost {
+		public.Set("address", obsHost)
+	}
+}
+
+// fixStationAddressForEndpoint is fixStationEndpoint for the single station a host
+// re-reports at ReplaceURL (its post-NAT LAN url, carrying the RVCID peers need). The
+// same VPN-looking address comes back here; repoint it at the hairpin source so the
+// dedupe-by-address in handleReplaceURL keeps one local station the natbridge can pair.
+func fixStationAddressForEndpoint(conn *Connection, st *StationURL, cfg SecureConnectionConfig) {
+	obsHost, _, err := net.SplitHostPort(conn.RemoteAddr)
+	if err != nil || obsHost == "" || !isPrivateIP(obsHost) || cfg.PublicHost == "" {
+		return
+	}
+	if !isPrivateIP(st.Get("address")) {
+		st.Set("address", obsHost)
+	}
 }

--- a/secureconnection_test.go
+++ b/secureconnection_test.go
@@ -1,69 +1,83 @@
 package nex
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-func TestSecureConnectionRegister(t *testing.T) {
+// TestRegisterCoLocatedSingleURL reproduces the Splatoon 2 host shape that failed:
+// the client reports ONE station url carrying a VPN-looking address (Hamachi
+// 25.x), its connection arrives hairpinned from the router's LAN address. Register
+// must store a distinct local/public pair (bridge input) and answer with a public
+// station that points at the ALWAYS-LIVE, RESPONDING P2P anchor — the host's own
+// reported station (a VPN/LAN address) can never answer the resolve job's probes,
+// so the job cannot see a consistent client port and the host dies 2618-201.
+func TestRegisterCoLocatedSingleURL(t *testing.T) {
 	s := testSettings()
 	ep := NewEndpoint(s)
+	conn := newTestConn(ep, 1800002682, "192.168.1.1:61375")
 
-	conn := NewConnection(ep, "88.1.2.3:12345", func([]byte) {})
-	conn.PID = 1800000000
-	conn.ID = 42
+	nat := filepath.Join(t.TempDir(), "nat.txt")
+	t.Setenv("NNCS_NAT_FILE", nat)
+	if err := os.WriteFile(nat, []byte("192.168.1.1 50601\n90.246.6.248 50601\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-	// Client reports a LAN url and a public url (both without the Public flag,
-	// as the Switch does).
-	lan := NewStationURL("prudp")
-	lan.Set("address", "10.0.0.5")
-	lan.Set("port", "1234")
-	pub := NewStationURL("prudp")
-	pub.Set("address", "88.1.2.3")
-	pub.Set("port", "5678")
+	cfg := LegacyPiaConfig()
+	cfg.PublicHost = "90.246.6.248"
+	cfg.P2PAnchorPort = 33334
+
+	url := NewStationURL("prudp")
+	url.Set("address", "25.42.44.246")
+	url.SetInt("port", 1)
+	url.SetInt("sid", 30)
+	url.Set("Pl", "3")
+	url.Set("Tpt", "2")
+	url.Set("natf", "0")
+	url.Set("natm", "0")
+	url.Set("pmp", "0")
+	url.Set("upnp", "0")
 
 	body := NewStreamOut(s)
-	WriteList(body, []*StationURL{lan, pub}, func(o *StreamOut, u *StationURL) { o.StationURL(u) })
-	req := NewRMCRequest(s, ProtocolSecureConnection, MethodRegister, 3, body.Bytes())
+	WriteList(body, []*StationURL{url}, func(o *StreamOut, u *StationURL) { o.StationURL(u) })
+	resp := handleRegister(conn, NewRMCRequest(s, ProtocolSecureConnection, MethodRegister, 1, body.Bytes()), cfg)
+	if resp == nil {
+		t.Fatal("register returned nil")
+	}
 
-	resp := SecureConnectionHandler()(conn, req)
-	if resp.IsError {
-		t.Fatalf("register errored: %+v", resp)
+	st := conn.Stations()
+	if len(st) != 2 {
+		t.Fatalf("stored stations len=%d (want 2 distinct), got %+v", len(st), st)
+	}
+	var localAddr string
+	publicPort := -1
+	for _, u := range st {
+		if isPrivateIP(u.Get("address")) {
+			localAddr = u.Get("address")
+		} else {
+			publicPort = u.GetInt("port")
+		}
+	}
+	if localAddr != "192.168.1.1" {
+		t.Errorf("stored local = %q, want the hairpin source 192.168.1.1", localAddr)
+	}
+	if publicPort != 33334 {
+		t.Errorf("stored public port = %d, want the P2P anchor 33334 (the host's own station can never answer probes)", publicPort)
 	}
 
 	in := NewStreamIn(resp.Body, s)
-	retval := in.U32()
-	cid := in.U32()
-	urlPublic := ParseStationURL(in.String())
-
-	if retval != ResultCoreUnknown {
-		t.Fatalf("retval %#x", retval)
+	in.U32() // retval
+	in.U32() // pidConnectionID
+	respURL := in.StationURLValue()
+	if respURL == nil {
+		t.Fatal("register response carries no urlPublic")
 	}
-	if cid != 42 {
-		t.Fatalf("connection id %d", cid)
+	if got := respURL.Get("address"); got != "90.246.6.248" {
+		t.Errorf("resp address = %q, want 90.246.6.248 (the anchor the host can actually probe)", got)
 	}
-	if urlPublic.GetInt("type") != 0x0B {
-		t.Fatalf("public type %d (want 0x0B)", urlPublic.GetInt("type"))
-	}
-	if urlPublic.Get("Pa") != "10.0.0.5" {
-		t.Fatalf("Pa %q (want the LAN address)", urlPublic.Get("Pa"))
-	}
-	if urlPublic.GetInt("RVCID") != 42 {
-		t.Fatalf("RVCID %d", urlPublic.GetInt("RVCID"))
-	}
-	if len(conn.Stations()) != 2 {
-		t.Fatalf("stored %d station urls", len(conn.Stations()))
-	}
-}
-
-func TestConnectionRegistry(t *testing.T) {
-	ep := NewEndpoint(testSettings())
-	c := NewConnection(ep, "1.2.3.4:1", func([]byte) {})
-
-	ep.registerConnection(c)
-	if c.ID == 0 || ep.FindConnectionByID(c.ID) != c {
-		t.Fatalf("register failed: id=%d", c.ID)
-	}
-	c.close()
-	if ep.FindConnectionByID(c.ID) != nil {
-		t.Fatal("connection not removed on close")
+	if got := respURL.GetInt("port"); got != 33334 {
+		t.Errorf("resp port = %d, want the P2P anchor 33334 (the resolve target must answer)", got)
 	}
 }
 
@@ -90,5 +104,116 @@ func TestIsPrivateIPUsesRealRanges(t *testing.T) {
 		if got := isPrivateIP(c.addr); got != c.want {
 			t.Errorf("isPrivateIP(%q) = %v, want %v (%s)", c.addr, got, c.want, c.why)
 		}
+	}
+}
+
+// TestRegisterCoLocatedTwoURLs: a host that reports a real private LAN url AND a
+// VPN-looking public url. The private local must be kept; only the public is
+// repointed.
+func TestRegisterCoLocatedTwoURLs(t *testing.T) {
+	s := testSettings()
+	ep := NewEndpoint(s)
+	conn := newTestConn(ep, 1800002683, "192.168.1.1:61376")
+
+	nat := filepath.Join(t.TempDir(), "nat.txt")
+	t.Setenv("NNCS_NAT_FILE", nat)
+	if err := os.WriteFile(nat, []byte("192.168.1.1 51700\n90.246.6.248 51700\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LegacyPiaConfig()
+	cfg.PublicHost = "90.246.6.248"
+	cfg.P2PAnchorPort = 33334
+
+	local := NewStationURL("prudp")
+	local.Set("address", "192.168.1.70")
+	local.SetInt("port", 1)
+	pub := NewStationURL("prudp")
+	pub.Set("address", "25.42.44.246")
+	pub.SetInt("port", 1)
+
+	body := NewStreamOut(s)
+	WriteList(body, []*StationURL{local, pub}, func(o *StreamOut, u *StationURL) { o.StationURL(u) })
+	resp := handleRegister(conn, NewRMCRequest(s, ProtocolSecureConnection, MethodRegister, 1, body.Bytes()), cfg)
+	if resp == nil {
+		t.Fatal("register returned nil")
+	}
+
+	var localAddr, publicAddr string
+	publicPort := -1
+	for _, u := range conn.Stations() {
+		if isPrivateIP(u.Get("address")) {
+			localAddr = u.Get("address")
+		} else {
+			publicAddr = u.Get("address")
+			publicPort = u.GetInt("port")
+		}
+	}
+	if localAddr != "192.168.1.70" {
+		t.Errorf("stored local = %q, want the reported private LAN 192.168.1.70", localAddr)
+	}
+	if publicAddr != "90.246.6.248" || publicPort != 33334 {
+		t.Errorf("stored public = %s:%d, want 90.246.6.248:33334 (the P2P anchor)", publicAddr, publicPort)
+	}
+
+	in := NewStreamIn(resp.Body, s)
+	in.U32()
+	in.U32()
+	respURL := in.StationURLValue()
+	if respURL == nil || respURL.Get("address") != "90.246.6.248" || respURL.GetInt("port") != 33334 {
+		t.Errorf("resp url = %+v, want address 90.246.6.248 port 33334", respURL)
+	}
+}
+
+// TestRegisterRemoteClient: a remote friend behind a normal private LAN. The
+// public station must point at the observed endpoint and the response must match
+// it (stock behaviour is preserved for clients the anchor cannot help).
+func TestRegisterRemoteClient(t *testing.T) {
+	s := testSettings()
+	ep := NewEndpoint(s)
+	conn := newTestConn(ep, 1800002684, "88.77.66.55:30000")
+
+	nat := filepath.Join(t.TempDir(), "nat.txt")
+	t.Setenv("NNCS_NAT_FILE", nat)
+	if err := os.WriteFile(nat, []byte("88.77.66.55 41000\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LegacyPiaConfig()
+	cfg.PublicHost = "90.246.6.248"
+	cfg.P2PAnchorPort = 33334
+
+	url := NewStationURL("prudp")
+	url.Set("address", "192.168.0.10")
+	url.SetInt("port", 1)
+
+	body := NewStreamOut(s)
+	WriteList(body, []*StationURL{url}, func(o *StreamOut, u *StationURL) { o.StationURL(u) })
+	resp := handleRegister(conn, NewRMCRequest(s, ProtocolSecureConnection, MethodRegister, 1, body.Bytes()), cfg)
+	if resp == nil {
+		t.Fatal("register returned nil")
+	}
+
+	var localAddr, publicAddr string
+	for _, u := range conn.Stations() {
+		if isPrivateIP(u.Get("address")) {
+			localAddr = u.Get("address")
+		} else {
+			publicAddr = u.Get("address")
+		}
+	}
+	if localAddr != "192.168.0.10" {
+		t.Errorf("stored local = %q, want the reported LAN 192.168.0.10", localAddr)
+	}
+	if publicAddr != "88.77.66.55" {
+		t.Errorf("stored public = %q, want the observed endpoint", publicAddr)
+	}
+
+	in := NewStreamIn(resp.Body, s)
+	in.U32()
+	in.U32()
+	respURL := in.StationURLValue()
+	if respURL == nil || respURL.Get("address") != "88.77.66.55" {
+		t.Errorf("resp url = %+v, want address 88.77.66.55", respURL)
 	}
 }

--- a/server.go
+++ b/server.go
@@ -15,8 +15,9 @@ import (
 // validators (e.g. gorilla) reject — and gws accepts it. Each socket carries one
 // Connection.
 type Server struct {
-	Endpoint *Endpoint
-	conns    sync.Map // *gws.Conn -> *Connection
+	Endpoint          *Endpoint
+	conns             sync.Map // *gws.Conn -> *Connection
+	CustomHTTPHandler func(w http.ResponseWriter, r *http.Request)
 }
 
 // NewServer wraps an endpoint in a WebSocket transport.
@@ -30,7 +31,7 @@ func (s *Server) OnOpen(socket *gws.Conn) {
 		_ = socket.WriteMessage(gws.OpcodeBinary, b)
 	})
 	s.conns.Store(socket, conn)
-	fmt.Printf("[WS] open from %s\n", socket.RemoteAddr())
+	fmt.Printf("[%s] [WS] open from %s\n", ts(), socket.RemoteAddr())
 }
 
 // OnClose tears down the socket's Connection.
@@ -60,13 +61,23 @@ func (s *Server) OnMessage(socket *gws.Conn, message *gws.Message) {
 
 func (s *Server) mux() *http.ServeMux {
 	upgrader := gws.NewUpgrader(s, &gws.ServerOption{
-		ParallelEnabled: true,
+		// ParallelEnabled must stay FALSE: with it on, gws dispatches every
+		// message in its own goroutine, so the Connection's receive path
+		// (recvBuf/fragBuf, RMC handlers) would run concurrently per message —
+		// it is designed for strict serial processing. Parallel dispatch also
+		// lets gws.Recovery swallow a handler panic, leaving the console
+		// waiting forever on a response that will never come.
+		ParallelEnabled: false,
 		Recovery:        gws.Recovery,
 		ReadBufferSize:  64 * 1024,
 		WriteBufferSize: 64 * 1024,
 	})
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" && s.CustomHTTPHandler != nil {
+			s.CustomHTTPHandler(w, r)
+			return
+		}
 		socket, err := upgrader.Upgrade(w, r)
 		if err != nil {
 			fmt.Printf("[WS] upgrade failed from %s path=%q proto=%q: %v\n",


### PR DESCRIPTION
Friend presence for LM3, WIP, rebased on v0.1.3. Adds the nex APIs the luigis-mansion-3 server needs to build (NatPortForIP, SetStationRelay/StationRelay), pushNotifDataToFriends + PublishNotification, PID fallback in NAT traversal, isPrivateIP RFC1918/CGNAT fixes. Binaries NOT committed.