### PR TITLE
Fix MK8D tournament code field corruption

### DIFF
--- a/tournament.go
+++ b/tournament.go
@@ -25,7 +25,9 @@ package nex
 // fin que le client envoie à zéro et dont il ne dépend pas.
 
 import (
+	"bytes"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -49,6 +51,11 @@ const (
 	// tournamentMax borne le nombre de tournois retenus. Nintendo en sert 85 ;
 	// au-delà de cette borne on cesse d'en créer plutôt que de croître sans fin.
 	tournamentMax = 2000
+	// tournamentNameLengthOffset is the u16 byte length of the UTF-16 name,
+	// including its terminator, in the captured MK8D structure.
+	tournamentNameLengthOffset = 0x69
+	// The code string follows 0x40 bytes of rules after the name.
+	tournamentCodeAfterName = 0x40
 )
 
 // Tournament est un tournoi tel qu'il circule : sa structure d'origine, plus ce
@@ -87,8 +94,10 @@ func tournamentInit() {
 			var list []*Tournament
 			if json.Unmarshal(b, &list) == nil {
 				tournaments.mu.Lock()
+				quarantined := 0
 				for _, t := range list {
-					if t == nil || t.ID == 0 || len(t.Blob) == 0 {
+					if !validStoredTournament(t) {
+						quarantined++
 						continue
 					}
 					tournaments.byID[t.ID] = t
@@ -99,6 +108,9 @@ func tournamentInit() {
 				n := len(tournaments.byID)
 				tournaments.mu.Unlock()
 				fmt.Printf("[Tournoi] %d tournoi(s) restauré(s) depuis %s\n", n, tournamentFile)
+				if quarantined != 0 {
+					fmt.Printf("[Tournament] quarantined %d invalid persisted tournament(s) (not served)\n", quarantined)
+				}
 			}
 		}
 		go tournamentFlusher()
@@ -140,17 +152,57 @@ func newTournamentCode() string {
 	return string(out)
 }
 
-// lastEmptyString rend l'offset de la DERNIÈRE chaîne vide de la structure —
-// c'est là que va le code. Une chaîne NEX vide s'écrit u16(1) puis un octet nul ;
-// la capture en compte dix, et le code occupe systématiquement la dernière.
-func lastEmptyString(b []byte) int {
-	pos := -1
-	for i := 0; i+3 <= len(b); i++ {
-		if b[i] == 1 && b[i+1] == 0 && b[i+2] == 0 {
-			pos = i
+// tournamentCodeOffset locates the code field from the encoded name length.
+// Searching for the last 01 00 00 sequence is unsafe: a later integer may have
+// the same bytes and cause the remainder of the blob to be shifted.
+func tournamentCodeOffset(b []byte) int {
+	if len(b) < tournamentNameLengthOffset+2 {
+		return -1
+	}
+	nameLen := int(binary.LittleEndian.Uint16(b[tournamentNameLengthOffset:]))
+	// MK8D encodes the name as a UTF-16 string terminated by U+0000.
+	if nameLen < 2 || nameLen&1 != 0 {
+		return -1
+	}
+	i := tournamentNameLengthOffset + 2 + nameLen + tournamentCodeAfterName
+	if i < 0 || i+3 > len(b) {
+		return -1
+	}
+	return i
+}
+
+func validTournamentCode(code string) bool {
+	if len(code) != tournamentCodeLen {
+		return false
+	}
+	for i := range code {
+		if code[i] < '0' || code[i] > '9' {
+			return false
 		}
 	}
-	return pos
+	return true
+}
+
+func tournamentCodeMatches(b []byte, code string) bool {
+	i := tournamentCodeOffset(b)
+	if i < 0 || !validTournamentCode(code) {
+		return false
+	}
+	n := int(binary.LittleEndian.Uint16(b[i:]))
+	if n != tournamentCodeLen+1 || i+2+n > len(b) || b[i+2+n-1] != 0 {
+		return false
+	}
+	return bytes.Equal(b[i+2:i+2+tournamentCodeLen], []byte(code))
+}
+
+func validStoredTournament(t *Tournament) bool {
+	if t == nil || t.ID == 0 || len(t.Blob) < 12 || len(t.Blob) > tournamentMaxBlob+tournamentCodeLen {
+		return false
+	}
+	if binary.LittleEndian.Uint32(t.Blob) != t.ID {
+		return false
+	}
+	return tournamentCodeMatches(t.Blob, t.Code)
 }
 
 // stampTournament pose l'identifiant, la marque du tournoi et le code dans la
@@ -171,8 +223,8 @@ func stampTournament(payload []byte, id uint32, mark []byte, code string) []byte
 	}
 	out[0], out[1], out[2], out[3] = byte(id), byte(id>>8), byte(id>>16), byte(id>>24)
 	copy(out[4:12], mark)
-	i := lastEmptyString(out)
-	if i < 0 || code == "" {
+	i := tournamentCodeOffset(out)
+	if i < 0 || !validTournamentCode(code) || !bytes.Equal(out[i:i+3], []byte{1, 0, 0}) {
 		return out
 	}
 	// La chaîne vide (3 octets) devient une chaîne de 12 chiffres + terminateur.
@@ -193,7 +245,8 @@ func stampTournament(payload []byte, id uint32, mark []byte, code string) []byte
 // complétée. Exporté pour qu'un serveur de jeu puisse l'alimenter autrement.
 func (m *Matchmaking) CreateTournament(owner uint64, payload []byte) *Tournament {
 	tournamentInit()
-	if len(payload) == 0 || len(payload) > tournamentMaxBlob {
+	i := tournamentCodeOffset(payload)
+	if len(payload) == 0 || len(payload) > tournamentMaxBlob || i < 0 || !bytes.Equal(payload[i:i+3], []byte{1, 0, 0}) {
 		return nil
 	}
 	tournaments.mu.Lock()
@@ -210,6 +263,10 @@ func (m *Matchmaking) CreateTournament(owner uint64, payload []byte) *Tournament
 		Participants: []uint64{owner}, CreatedAt: time.Now().Unix(),
 	}
 	t.Blob = stampTournament(payload, id, mark, t.Code)
+	if !validStoredTournament(t) {
+		tournaments.mu.Unlock()
+		return nil
+	}
 	tournaments.byID[id] = t
 	tournaments.mu.Unlock()
 	tournamentDirty.Store(true)
@@ -221,7 +278,11 @@ func tournamentByID(id uint32) *Tournament {
 	tournamentInit()
 	tournaments.mu.RLock()
 	defer tournaments.mu.RUnlock()
-	return tournaments.byID[id]
+	t := tournaments.byID[id]
+	if !validStoredTournament(t) {
+		return nil
+	}
+	return t
 }
 
 func allTournaments() []*Tournament {
@@ -230,7 +291,9 @@ func allTournaments() []*Tournament {
 	defer tournaments.mu.RUnlock()
 	out := make([]*Tournament, 0, len(tournaments.byID))
 	for _, t := range tournaments.byID {
-		out = append(out, t)
+		if validStoredTournament(t) {
+			out = append(out, t)
+		}
 	}
 	return out
 }
@@ -283,8 +346,14 @@ func (m *Matchmaking) createTournament(conn *Connection, req *RMCMessage) *RMCMe
 // entrée u8 version, u32 longueur, contenu. Forme relevée sur la capture.
 func writeTournamentList(s *Settings, list []*Tournament) []byte {
 	out := NewStreamOut(s)
-	out.U32(uint32(len(list)))
+	valid := make([]*Tournament, 0, len(list))
 	for _, t := range list {
+		if validStoredTournament(t) {
+			valid = append(valid, t)
+		}
+	}
+	out.U32(uint32(len(valid)))
+	for _, t := range valid {
 		out.U8(1)
 		out.U32(uint32(len(t.Blob)))
 		out.Write(t.Blob)

--- a/tournament_capture_test.go
+++ b/tournament_capture_test.go
@@ -22,14 +22,20 @@ const captureCreateReq = "" +
 	"000003010000090400040000000a020000000b04008ead8b0f01040000000000ff000000000100000020000000000000" +
 	"006009060000000000c0120000000019aa1f00000000101baa1f000000000000000000000000000000"
 
+func capturedTournamentPayload(t *testing.T) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(captureCreateReq)
+	if err != nil {
+		t.Fatalf("hex invalide : %v", err)
+	}
+	return b
+}
+
 // TestStampTournamentReproducesCapture : poser identifiant, propriétaire et code
 // doit produire exactement ce que Nintendo a renvoyé — hors les trois octets de
 // queue, un compteur que le client envoie à zéro et dont il ne dépend pas.
 func TestStampTournamentReproducesCapture(t *testing.T) {
-	req, err := hex.DecodeString(captureCreateReq)
-	if err != nil {
-		t.Fatalf("hex invalide : %v", err)
-	}
+	req := capturedTournamentPayload(t)
 
 	const (
 		id   = uint32(3854367)
@@ -63,6 +69,28 @@ func TestStampTournamentReproducesCapture(t *testing.T) {
 	}
 }
 
+// A later u32 value of 1 is also encoded as 01 00 00 00. The old "last empty
+// string" heuristic inserted the code there and produced a shifted MK8D blob.
+func TestStampTournamentIgnoresLaterEmptyPattern(t *testing.T) {
+	req := capturedTournamentPayload(t)
+	codeOffset := tournamentCodeOffset(req)
+	if codeOffset != 0xb5 {
+		t.Fatalf("code offset = %#x, want 0xb5", codeOffset)
+	}
+	req[0xd0], req[0xd1], req[0xd2], req[0xd3] = 1, 0, 0, 0
+
+	const code = "123456789012"
+	got := stampTournament(req, 4242, make([]byte, 8), code)
+	if !tournamentCodeMatches(got, code) {
+		t.Fatal("code was not written to its structural field")
+	}
+	// The later binary pattern must remain u32(1), not become a string. Writing
+	// the code at the correct field shifts this later value by 12 bytes.
+	if !bytes.Equal(got[0xd0+12:0xd4+12], []byte{1, 0, 0, 0}) {
+		t.Fatalf("later field was modified: %x", got[0xd0+12:0xd4+12])
+	}
+}
+
 // TestNewTournamentCode : douze chiffres, comme celui de Nintendo.
 func TestNewTournamentCode(t *testing.T) {
 	for i := 0; i < 50; i++ {
@@ -81,9 +109,7 @@ func TestNewTournamentCode(t *testing.T) {
 // TestTournamentLifecycle : créer, retrouver, inscrire.
 func TestTournamentLifecycle(t *testing.T) {
 	m := NewMatchmaking()
-	payload := make([]byte, 200)
-	// une chaîne vide en fin de structure, comme le fait le client pour le code
-	payload[150], payload[151], payload[152] = 1, 0, 0
+	payload := capturedTournamentPayload(t)
 
 	tr := m.CreateTournament(1800000006, payload)
 	if tr == nil {
@@ -111,8 +137,7 @@ func TestTournamentLifecycle(t *testing.T) {
 // sans ce contrôle, n'importe qui effacerait le tournoi d'un autre.
 func TestDeleteTournamentOwnerOnly(t *testing.T) {
 	m := NewMatchmaking()
-	payload := make([]byte, 200)
-	payload[150], payload[151], payload[152] = 1, 0, 0
+	payload := capturedTournamentPayload(t)
 
 	tr := m.CreateTournament(1800000006, payload)
 	if tr == nil {
@@ -132,5 +157,51 @@ func TestDeleteTournamentOwnerOnly(t *testing.T) {
 	}
 	if deleteTournament(tr.ID, 1800000006) {
 		t.Error("une seconde suppression devrait échouer")
+	}
+}
+
+func TestCreateTournamentRejectsInvalidPayloads(t *testing.T) {
+	m := NewMatchmaking()
+	badCode := capturedTournamentPayload(t)
+	badCode[tournamentCodeOffset(badCode)] = 2 // The creator must send an empty code.
+	oddName := capturedTournamentPayload(t)
+	oddName[tournamentNameLengthOffset] = 3
+	valid := capturedTournamentPayload(t)
+	oversized := append(valid, make([]byte, tournamentMaxBlob+1-len(valid))...)
+
+	cases := []struct {
+		name    string
+		payload []byte
+	}{
+		{"empty", nil},
+		{"truncated", make([]byte, tournamentNameLengthOffset+1)},
+		{"odd name length", oddName},
+		{"non-empty or malformed code field", badCode},
+		{"oversized", oversized},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tr := m.CreateTournament(1800000006, tc.payload); tr != nil {
+				t.Fatal("invalid tournament payload was stored")
+			}
+		})
+	}
+}
+
+func TestWriteTournamentListIsolatesInvalidEntry(t *testing.T) {
+	s := testSettings()
+	payload := capturedTournamentPayload(t)
+	valid := (&Matchmaking{}).CreateTournament(1800000006, payload)
+	if valid == nil {
+		t.Fatal("valid tournament was rejected")
+	}
+	bad := *valid
+	bad.Blob = append([]byte(nil), valid.Blob...)
+	bad.Blob[tournamentCodeOffset(bad.Blob)+2] = 'X'
+
+	body := writeTournamentList(s, []*Tournament{&bad, valid})
+	in := NewStreamIn(body, s)
+	if n := in.U32(); n != 1 {
+		t.Fatalf("list declares %d entries, want 1", n)
 	}
 }


### PR DESCRIPTION
## Summary

- Locate the MK8D tournament code field from the encoded UTF-16 name length instead of searching for the last empty-string byte pattern.
- Reject malformed tournament payloads before persistence.
- Quarantine invalid persisted tournaments and filter invalid entries individually when serializing lists.
- Add regression coverage for ambiguous byte patterns, malformed inputs, and per-entry isolation.

## Root cause

The previous last-empty-string heuristic was ambiguous. A later integer can also contain `01 00 00`, causing the generated 12-digit code to be inserted into the wrong field and shifting the remaining tournament structure. MK8D then interprets shifted string bytes as date-related fields and can crash while processing the tournament list.

## Validation

- `go test ./...`
- Existing capture-based tournament transformation test remains passing.
- New regression reproduces a later `01 00 00 00` collision without including production capture data.

## Compatibility

Valid tournament blobs retain their existing serialized form. Invalid persisted entries are omitted individually so one bad tournament cannot poison an entire response.