### PR TITLE
ranking: read the name deposited in the MK8 profile, so reports can be attributed

### DIFF
--- a/ranking.go
+++ b/ranking.go
@@ -231,6 +231,7 @@ func uploadCommonData(conn *Connection, req *RMCMessage) *RMCMessage {
 	blob := in.Buffer()
 	if in.Err() == nil {
 		PutCommonData(conn.PID, blob)
+		logCommonDataNames(conn.PID, blob)
 	}
 	return NewRMCSuccess(conn.Settings, ProtocolRanking, req.Method, req.CallID, nil)
 }

--- a/ranking_names.go
+++ b/ranking_names.go
@@ -1,0 +1,142 @@
+package nex
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+	"unicode/utf16"
+)
+
+// Lecture des noms portés par le profil MK8 (protocole Ranking, méthode 0x04).
+//
+// ranking.go stocke ce bloc TEL QUEL et le rediffuse, ce qui suffit à faire
+// réapparaître pseudos et drapeaux en course, sans interpréter le format. Ce
+// fichier fait la seule chose que ce choix laissait de côté : LIRE le nom. Ce
+// n'est pas nécessaire au jeu ; ça l'est à la modération.
+//
+// Le serveur ne voit jamais la course — elle se joue en P2P — et /api/stats ne
+// sait produire que « Joueur-<pid> ». Un signalement (« untel trichait ») ne peut
+// donc être rattaché à personne. Or des joueurs se présentent sous le nom d'un
+// AUTRE, ou sans nom, ou en « Player » : bannir sur la foi d'un nom reviendrait
+// à bannir la VICTIME de l'usurpation plutôt que son auteur. Lire le nom déposé
+// par un PID authentifié rend trois cas détectables sans rien voir de la course :
+// un nom qui appartient à un autre compte, un nom vide ou générique, un nom qui
+// change d'une session à l'autre.
+//
+// Disposition relevée sur la capture Nintendo du 2026-08-12 (bloc de 132 octets),
+// telle que documentée en tête de ranking.go :
+//
+//	[0:4]    52 46 00 00   signature
+//	[4:20]   identifiant Mii
+//	[20:42]  nom Mii, UTF-16LE, 22 octets
+//	[42:...] pseudo en jeu, UTF-16LE
+//
+// Tout ce qui sort d'ici vient du CLIENT. C'est une donnée hostile, pas une
+// identité : bornée, nettoyée, et jamais suffisante à elle seule pour sanctionner.
+
+const (
+	// commonDataMiiNameOff / Len : le nom Mii, à position fixe dans le bloc.
+	commonDataMiiNameOff = 20
+	commonDataMiiNameLen = 22
+	// commonDataNickOff : le pseudo en jeu suit immédiatement le nom Mii. Sa
+	// longueur n'est pas documentée par la capture, on lit donc jusqu'au
+	// terminateur plutôt que de figer une taille qu'on ne connaît pas.
+	commonDataNickOff = commonDataMiiNameOff + commonDataMiiNameLen
+	// commonDataMaxNameRunes borne ce qui ressort. Le client peut déposer ce
+	// qu'il veut ; un nom démesuré dans un journal ou une interface de
+	// modération serait un moyen de nuire, pas un nom.
+	commonDataMaxNameRunes = 32
+)
+
+// commonDataMagic : les quatre premiers octets du bloc. Un profil qui ne les
+// porte pas n'a pas été produit par un jeu intact — c'est en soi un signal.
+var commonDataMagic = []byte{0x52, 0x46, 0x00, 0x00}
+
+// CommonDataNames rend le nom Mii et le pseudo en jeu déposés dans ce profil.
+//
+// ok vaut false quand le bloc ne correspond pas à la disposition connue : trop
+// court, ou signature absente. Ce n'est pas une erreur à ignorer — un profil
+// non conforme déposé par une connexion authentifiée mérite d'être remonté.
+func CommonDataNames(blob []byte) (miiName, nickname string, ok bool) {
+	if len(blob) < commonDataNickOff+2 {
+		return "", "", false
+	}
+	for i, b := range commonDataMagic {
+		if blob[i] != b {
+			return "", "", false
+		}
+	}
+	miiName = decodeUTF16LE(blob[commonDataMiiNameOff : commonDataMiiNameOff+commonDataMiiNameLen])
+	nickname = decodeUTF16LE(blob[commonDataNickOff:])
+	return miiName, nickname, true
+}
+
+// decodeUTF16LE lit une chaîne UTF-16LE jusqu'au terminateur, puis la nettoie.
+// Un octet impair en fin de tranche est ignoré : on préfère un nom tronqué à un
+// décodage qui déborde.
+func decodeUTF16LE(b []byte) string {
+	units := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		u := uint16(b[i]) | uint16(b[i+1])<<8
+		if u == 0 { // terminateur : le reste de la zone est du remplissage
+			break
+		}
+		units = append(units, u)
+		if len(units) >= commonDataMaxNameRunes {
+			break
+		}
+	}
+	return sanitizeName(string(utf16.Decode(units)))
+}
+
+// sanitizeName retire ce qui n'a rien à faire dans un nom affiché ou journalisé.
+// Les caractères de contrôle sont écartés d'abord : ils permettraient d'injecter
+// des retours ligne dans un journal, donc d'y fabriquer des lignes crédibles.
+func sanitizeName(s string) string {
+	var sb strings.Builder
+	n := 0
+	for _, r := range s {
+		if r == unicode.ReplacementChar || !unicode.IsGraphic(r) {
+			continue
+		}
+		sb.WriteRune(r)
+		if n++; n >= commonDataMaxNameRunes {
+			break
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+// CommonDataNamesForPID rend les noms du profil déjà stocké pour ce PID. C'est
+// le point d'entrée d'une consultation de modération : partir du PID, qui est
+// authentifié, et non du nom, qui ne l'est pas.
+func CommonDataNamesForPID(pid uint64) (miiName, nickname string, ok bool) {
+	blob := CommonData(pid)
+	if blob == nil {
+		return "", "", false
+	}
+	return CommonDataNames(blob)
+}
+
+// logProfileNames : la journalisation des noms est OPTIONNELLE et coupée par
+// défaut. Ce sont des données nominatives — ranking.go range déjà les profils en
+// 0600 pour cette raison — et les journaux de ces serveurs sont volumineux et peu
+// protégés. On l'allume quand on enquête, pas en permanence.
+var logProfileNames = os.Getenv("NEXTENDO_LOG_PROFILE_NAMES") == "1"
+
+// logCommonDataNames trace le nom annoncé par un PID authentifié : de quoi
+// rattacher un signalement à un compte, ce qu'aucune autre trace ne permet.
+func logCommonDataNames(pid uint64, blob []byte) {
+	if !logProfileNames {
+		return
+	}
+	mii, nick, ok := CommonDataNames(blob)
+	if !ok {
+		// Un bloc non conforme est plus intéressant qu'un bloc ordinaire : on le
+		// signale même si on ne sait pas le lire.
+		fmt.Printf("[Ranking] profil NON CONFORME pid=%d taille=%d\n", pid, len(blob))
+		return
+	}
+	fmt.Printf("[Ranking] profil pid=%d mii=%q pseudo=%q\n", pid, mii, nick)
+}

--- a/ranking_names_test.go
+++ b/ranking_names_test.go
@@ -1,0 +1,124 @@
+package nex
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
+
+// profilMK8 fabrique un bloc conforme à la disposition relevée sur la capture
+// Nintendo, pour éprouver le décodage sans dépendre d'un profil réel — les vrais
+// sont des données nominatives et n'ont rien à faire dans un dépôt.
+func profilMK8(mii, pseudo string) []byte {
+	b := make([]byte, 132)
+	copy(b, commonDataMagic)
+	put := func(off int, s string, max int) {
+		for i, u := range utf16.Encode([]rune(s)) {
+			if off+i*2+1 >= len(b) || i*2 >= max {
+				return
+			}
+			b[off+i*2] = byte(u)
+			b[off+i*2+1] = byte(u >> 8)
+		}
+	}
+	put(commonDataMiiNameOff, mii, commonDataMiiNameLen)
+	put(commonDataNickOff, pseudo, 40)
+	return b
+}
+
+func TestCommonDataNamesLitLesDeuxNoms(t *testing.T) {
+	mii, pseudo, ok := CommonDataNames(profilMK8("Yaacob", "ya'akov"))
+	if !ok {
+		t.Fatal("bloc conforme refusé")
+	}
+	if mii != "Yaacob" {
+		t.Errorf("nom Mii : %q, attendu %q", mii, "Yaacob")
+	}
+	if pseudo != "ya'akov" {
+		t.Errorf("pseudo : %q, attendu %q", pseudo, "ya'akov")
+	}
+}
+
+// Les noms non latins doivent survivre : une part des joueurs en utilise, et un
+// décodage qui les mutile rendrait la modération injuste pour eux seuls.
+func TestCommonDataNamesGardeLeNonLatin(t *testing.T) {
+	_, pseudo, ok := CommonDataNames(profilMK8("Mii", "アナキン"))
+	if !ok || pseudo != "アナキン" {
+		t.Fatalf("pseudo : %q ok=%v, attendu %q", pseudo, ok, "アナキン")
+	}
+}
+
+// Le cas qui motive tout ce fichier : un client modifié qui ne dépose rien de
+// conforme. On doit le distinguer d'un profil ordinaire, pas l'avaler.
+func TestCommonDataNamesRefuseUnBlocNonConforme(t *testing.T) {
+	cas := map[string][]byte{
+		"vide":              nil,
+		"trop court":        make([]byte, 10),
+		"sans signature":    make([]byte, 132),
+		"signature altérée": append([]byte{0x52, 0x46, 0x01, 0x00}, make([]byte, 128)...),
+	}
+	for nom, blob := range cas {
+		if _, _, ok := CommonDataNames(blob); ok {
+			t.Errorf("%s : accepté alors qu'il aurait dû être refusé", nom)
+		}
+	}
+}
+
+// Un pseudo vide est licite côté format : c'est un signal de modération, pas une
+// erreur de décodage. Il doit ressortir comme chaîne vide avec ok=true.
+func TestCommonDataNamesPseudoVide(t *testing.T) {
+	_, pseudo, ok := CommonDataNames(profilMK8("Mii", ""))
+	if !ok {
+		t.Fatal("bloc conforme au pseudo vide refusé")
+	}
+	if pseudo != "" {
+		t.Errorf("pseudo : %q, attendu vide", pseudo)
+	}
+}
+
+// Le nom vient du client. Un pseudo démesuré ne doit pas pouvoir inonder un
+// journal ni une interface de modération.
+func TestCommonDataNamesBorneLaLongueur(t *testing.T) {
+	_, pseudo, ok := CommonDataNames(profilMK8("Mii", strings.Repeat("A", 200)))
+	if !ok {
+		t.Fatal("bloc refusé")
+	}
+	if n := len([]rune(pseudo)); n > commonDataMaxNameRunes {
+		t.Fatalf("pseudo de %d runes, la borne était %d", n, commonDataMaxNameRunes)
+	}
+}
+
+// Un retour ligne dans un pseudo permettrait de fabriquer de fausses lignes dans
+// les journaux, donc de faire accuser quelqu'un d'autre. Il doit disparaître.
+func TestCommonDataNamesRetireLesCaracteresDeControle(t *testing.T) {
+	_, pseudo, ok := CommonDataNames(profilMK8("Mii", "abc\ndef"))
+	if !ok {
+		t.Fatal("bloc refusé")
+	}
+	if strings.ContainsAny(pseudo, "\n\r\t") {
+		t.Fatalf("pseudo %q contient encore un caractère de contrôle", pseudo)
+	}
+}
+
+// Le nom Mii ne doit pas déborder sur le pseudo qui le suit immédiatement :
+// c'est l'erreur qui ferait lire un nom pour un autre.
+func TestCommonDataNamesNeDeborderPasSurLeChampSuivant(t *testing.T) {
+	mii, pseudo, ok := CommonDataNames(profilMK8("AAAAAAAAAAA", "BBBBBBBB"))
+	if !ok {
+		t.Fatal("bloc refusé")
+	}
+	if strings.Contains(mii, "B") {
+		t.Errorf("le nom Mii %q a mordu sur le pseudo", mii)
+	}
+	if strings.Contains(pseudo, "A") {
+		t.Errorf("le pseudo %q a mordu sur le nom Mii", pseudo)
+	}
+}
+
+// CommonDataNamesForPID part du PID, qui est authentifié. Un PID inconnu rend
+// ok=false plutôt qu'un nom vide qu'on pourrait confondre avec un pseudo vide.
+func TestCommonDataNamesForPIDInconnu(t *testing.T) {
+	if _, _, ok := CommonDataNamesForPID(0xFFFFFFFFFFFF); ok {
+		t.Fatal("un PID sans profil ne doit pas rendre ok=true")
+	}
+}


### PR DESCRIPTION
Adds the one thing the current profile handling deliberately left out: **reading the name**.

### Why

`ranking.go` stores the MK8 profile blob as-is and relays it, which is enough for nicknames and flags to reappear in-game without interpreting the format. That was the right call for making the game work — but it means nothing on the server ever knows what a player is called.

The server never sees the race (it runs P2P), and `/api/stats` can only produce `Joueur-<pid>`. So a report — "this player was cheating" — cannot be attached to any account. We measured that the hard way: searching 11,000 accounts for a reported player name produced only a phonetic guess, which is not something you can act on.

Meanwhile players are showing up **under other people's names**, with blank names, or as `Player`. That makes the current situation worse than useless: banning on the strength of a name would ban the *victim* of the impersonation rather than its author.

### What this enables

Reading the name deposited by an **authenticated PID** makes three cases detectable without observing the race at all:

- a name that belongs to a different account → impersonation
- a blank or generic name → modified client
- a name that changes between sessions

### How

`CommonDataNames` reads the layout already documented at the top of `ranking.go` — signature `52 46 00 00`, Mii ID, Mii name in UTF-16 over 22 bytes, then the in-game nickname. A non-conforming block returns `ok=false` rather than a best guess: arriving on an authenticated connection, that is itself a signal worth surfacing.

`CommonDataNamesForPID` is the moderation entry point, deliberately keyed on the PID (authenticated) rather than the name (not).

### Treating the name as hostile

It comes from the client, so it is bounded to 32 runes and stripped of control characters. Without that, a newline inside a nickname would let someone forge convincing log lines and get another player accused.

### Privacy

Logging is **off by default**, behind `NEXTENDO_LOG_PROFILE_NAMES=1`. These are nominative data — `ranking.go` already stores profiles `0600` for that reason — and these servers' logs are large and not well protected. Turn it on to investigate, not permanently.

### Scope

Nothing changes for the game: the response to the upload is byte-identical. Eight tests cover the layout, non-Latin names, blank nicknames, the length bound, control-character stripping, field-boundary overrun, and non-conforming blocks.

---

**Open question for review:** the nickname offset comes from the documented capture, but its *length* isn't specified there, so it's read to the terminator. Worth confirming against a real profile — happy to adjust if the field is fixed-width.
